### PR TITLE
Turn on Julia formatting in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,11 +44,11 @@ repos:
 #####
 # Julia
 # Due to lack of first-class Julia support, this needs Julia local install
-#   and JuliaFormatter.jl installed in the library
-# - repo: https://github.com/domluna/JuliaFormatter.jl
-#   rev: v1.0.39
-#   hooks:
-#   - id: julia-formatter
+#  and JuliaFormatter.jl installed in the library
+- repo: https://github.com/domluna/JuliaFormatter.jl
+  rev: v1.0.39
+  hooks:
+  - id: julia-formatter
 #####
 # Secrets
 -   repo: https://github.com/Yelp/detect-secrets

--- a/EpiAware/src/latent-processes.jl
+++ b/EpiAware/src/latent-processes.jl
@@ -17,7 +17,7 @@ Constructs a random walk model.
     ϵ_t = missing,
     ::Type{T} = Float64;
     latent_process_priors = (var_RW_dist = truncated(Normal(0.0, 0.05), 0.0, Inf),),
-) where {T <: Real}
+) where {T<:Real}
     rw = Vector{T}(undef, n)
     ϵ_t ~ MvNormal(ones(n))
     σ²_RW ~ latent_process_priors.var_RW_dist


### PR DESCRIPTION
This PR turns on Julia formatting in precommit and auto-formats code that failed checks (`latent-processes.jl`).