### PR TITLE
Initialisation for epidemic inference

### DIFF
--- a/EpiAware/src/EpiAware.jl
+++ b/EpiAware/src/EpiAware.jl
@@ -35,16 +35,19 @@ export scan,
     create_discrete_pmf,
     growth_rate_to_reproductive_ratio,
     generate_observation_kernel,
-    default_rw_priors
+    default_rw_priors,
+    neg_MGF,
+    dneg_MGF_dr,
+    fast_R_to_r_approx
 
 # Exported types
-export EpiData, Renewal, ExpGrowthRate, DirectInfections
+export EpiData, Renewal, ExpGrowthRate, DirectInfections, AbstractEpiModel
 
 # Exported Turing model constructors
 export make_epi_inference_model, random_walk
 
-include("utilities.jl")
 include("epimodel.jl")
+include("utilities.jl")
 include("models.jl")
 include("latent-processes.jl")
 

--- a/EpiAware/src/latent-processes.jl
+++ b/EpiAware/src/latent-processes.jl
@@ -14,12 +14,12 @@ end
     rw = Vector{T}(undef, n)
     ϵ_t ~ MvNormal(ones(n))
     σ²_RW ~ latent_process_priors.var_RW_dist
-    init_rw_value ~ latent_process_priors.init_rw_value_dist
+    init ~ latent_process_priors.init_rw_value_dist
     σ_RW = sqrt(σ²_RW)
 
-    rw[1] = init_rw_value + σ_RW * ϵ_t[1]
+    rw[1] = σ_RW * ϵ_t[1]
     for t = 2:n
         rw[t] = rw[t-1] + σ_RW * ϵ_t[t]
     end
-    return rw, (; σ_RW, init_rw_value, init = rw[1])
+    return rw, (; σ_RW, init)
 end

--- a/EpiAware/src/models.jl
+++ b/EpiAware/src/models.jl
@@ -12,11 +12,11 @@
 
     #Latent process
     time_steps = epimodel.data.time_horizon
-    @submodel latent_process, latent_process_parameters =
+    @submodel latent_process, latent_process_aux =
         latent_process(time_steps; latent_process_priors = latent_process_priors)
 
     #Transform into infections
-    I_t, _ = scan(epimodel, latent_process_parameters.init, latent_process)
+    I_t = epimodel(latent_process, latent_process_aux)
 
     #Predictive distribution
     case_pred_dists =
@@ -27,5 +27,5 @@
     y_t ~ arraydist(case_pred_dists)
 
     #Generate quantities
-    return (; I_t, latent_process_parameters)
+    return (; I_t, latent_process, latent_process_aux)
 end

--- a/EpiAware/src/utilities.jl
+++ b/EpiAware/src/utilities.jl
@@ -17,7 +17,7 @@ value. This is similar to the JAX function `jax.lax.scan`.
 - `ys`: An array containing the result values of applying `f` to each element of `xs`.
 - `carry`: The final accumulator value.
 """
-function scan(f, init, xs)
+function scan(f::Function, init, xs::Vector{T}) where {T<:Union{Integer,AbstractFloat}}
     carry = init
     ys = similar(xs)
     for (i, x) in enumerate(xs)
@@ -110,6 +110,46 @@ function create_discrete_pmf(dist::Distribution; Δd = 1.0, D)
 end
 
 """
+    neg_MGF(r, w::AbstractVector)
+
+Compute the negative moment generating function (MGF) for a given rate `r` and weights `w`.
+
+# Arguments
+- `r`: The rate parameter.
+- `w`: An abstract vector of weights.
+
+# Returns
+The value of the negative MGF.
+
+"""
+function neg_MGF(r, w::AbstractVector)
+    return sum([w[i] * exp(-r * i) for i = 1:length(w)])
+end
+
+function dneg_MGF_dr(r, w::AbstractVector)
+    return -sum([w[i] * i * exp(-r * i) for i = 1:length(w)])
+end
+
+function fast_R_to_r_approx(R₀, w::Vector{T}; newton_steps = 1) where {T<:AbstractFloat}
+    mean_gen_time = dot(w, 1:length(w))
+    # Small r approximation as initial guess
+    r_approx = (R₀ - 1) / (R₀ * mean_gen_time)
+    # Newton's method
+    for _ = 1:newton_steps
+        r_approx +=
+            (1 - R₀ * neg_MGF(r_approx, w)) * neg_MGF(r_approx, w) /
+            dneg_MGF_dr(r_approx, w)
+    end
+    return r_approx
+end
+
+function fast_R_to_r_approx(R₀, epimodel::AbstractEpiModel; newton_steps = 3)
+    fast_R_to_r_approx(R₀, epimodel.data.gen_int; newton_steps = newton_steps)
+end
+
+
+
+"""
     growth_rate_to_reproductive_ratio(r, w)
 
 Compute the reproductive ratio given exponential growth rate `r`
@@ -123,7 +163,7 @@ Compute the reproductive ratio given exponential growth rate `r`
 - The reproductive ratio.
 """
 function growth_rate_to_reproductive_ratio(r, w::AbstractVector)
-    return 1 / sum([w[i] * exp(-r * i) for i = 1:length(w)])
+    return 1 / neg_MGF(r, w::AbstractVector)
 end
 
 

--- a/EpiAware/src/utilities.jl
+++ b/EpiAware/src/utilities.jl
@@ -136,14 +136,12 @@ function fast_R_to_r_approx(R₀, w::Vector{T}; newton_steps = 1) where {T<:Abst
     r_approx = (R₀ - 1) / (R₀ * mean_gen_time)
     # Newton's method
     for _ = 1:newton_steps
-        r_approx +=
-            (1 - R₀ * neg_MGF(r_approx, w)) * neg_MGF(r_approx, w) /
-            dneg_MGF_dr(r_approx, w)
+        r_approx -= (R₀ * neg_MGF(r_approx, w) - 1) / (R₀ * dneg_MGF_dr(r_approx, w))
     end
     return r_approx
 end
 
-function fast_R_to_r_approx(R₀, epimodel::AbstractEpiModel; newton_steps = 3)
+function fast_R_to_r_approx(R₀, epimodel::AbstractEpiModel; newton_steps = 4)
     fast_R_to_r_approx(R₀, epimodel.data.gen_int; newton_steps = newton_steps)
 end
 

--- a/EpiAware/test/Aqua.jl
+++ b/EpiAware/test/Aqua.jl
@@ -1,6 +1,6 @@
 
 @testitem "Aqua.jl" begin
     using Aqua
-    Aqua.test_all(EpiAware, ambiguities = false)
+    Aqua.test_all(EpiAware, ambiguities = false, persistent_tasks = false)
     Aqua.test_ambiguities(EpiAware)
 end

--- a/EpiAware/test/predictive_checking/fast_approx_for_r.jl
+++ b/EpiAware/test/predictive_checking/fast_approx_for_r.jl
@@ -1,0 +1,78 @@
+#=
+# Fast approximation for `r` from `R₀`
+I use the negative moment generating function (MGF).
+
+Let
+```math
+G(r) = \sum_{i=1}^{\infty} w_i e^{-r i}.
+```
+and
+```math
+f(r, \mathcal{R}_0) = {1 \over G(r)} - \mathcal{R}_0.
+```
+then the connection between `R₀` and `r` is given by
+```math
+f(r, \mathcal{R}_0) = 0.
+```
+Given an estimate of $\mathcal{R}_0$ we implicit solve for $r$ using a root
+finder algorithm. In this note, I test a fast approximation for $r$ which
+should have good autodifferentiation properties. The idea is to start from the
+small $r$ approximation to the solution of $f(r, \mathcal{R}_0) = 0$ and then
+apply one step of Newton's method. The small $r$ approximation is given by
+```math
+r_0 = { \mathcal{R}_0 - 1 \over  \mathcal{R}_0 \langle W \rangle }.
+```
+where $\langle W \rangle$ is the mean of the generation interval.
+
+Note that
+```math
+\partial_r G(r, \mathcal{R}_0) = - {G'(r) \over G(r)^2} }
+```
+
+Therefore, each Newton step is given by
+```math
+r_{n+1} = r_n + {(1 - \mathcal{R}_0 G(r)) G(r) \over G'(r)}.
+```
+
+=#
+
+using TestEnv
+TestEnv.activate()
+using EpiAware
+using Distributions
+using StatsPlots
+
+# Create a discrete probability mass function (PMF) for a negative binomial distribution
+# with left truncation at 1.
+
+w =
+    create_discrete_pmf(NegativeBinomial(2, 0.5), D = 20.0) |>
+    p -> p[2:end] ./ sum(p[2:end])
+
+##
+
+jitter = 1e-17
+idxs = 0:10
+doubling_times = [1.0, 3.5, 7.0, 14.0]
+
+errors = mapreduce(hcat, doubling_times) do T_2
+    true_r = log(2) / T_2 # 7 day doubling time
+    R0 = growth_rate_to_reproductive_ratio(true_r, w)
+
+    return map(idxs) do ns
+        @time r = fast_R_to_r_approx(R0, w, newton_steps = ns)
+        abs(r - true_r) + jitter
+    end
+end
+
+plot(
+    idxs,
+    errors,
+    yscale = :log10,
+    xlabel = "Newton steps",
+    ylabel = "abs. Error",
+    title = "Fast approximation for r",
+    lab = ["T_2 = 1.0" "T_2 = 3.5" "T_2 = 7.0" "T_2 = 14.0"],
+    yticks = [0.0, 1e-15, 1e-10, 1e-5, 1e0] |> x -> (x .+ jitter, string.(x)),
+    xticks = 0:2:10,
+)

--- a/EpiAware/test/predictive_checking/fast_approx_for_r.jl
+++ b/EpiAware/test/predictive_checking/fast_approx_for_r.jl
@@ -8,7 +8,7 @@ G(r) = \sum_{i=1}^{\infty} w_i e^{-r i}.
 ```
 and
 ```math
-f(r, \mathcal{R}_0) = {1 \over G(r)} - \mathcal{R}_0.
+f(r, \mathcal{R}_0) = \mathcal{R}_0 G(r) - 1.
 ```
 then the connection between `R₀` and `r` is given by
 ```math
@@ -24,14 +24,9 @@ r_0 = { \mathcal{R}_0 - 1 \over  \mathcal{R}_0 \langle W \rangle }.
 ```
 where $\langle W \rangle$ is the mean of the generation interval.
 
-Note that
+To rapidly improve the estimate for `r` we use Newton steps given by
 ```math
-\partial_r G(r, \mathcal{R}_0) = - {G'(r) \over G(r)^2} }
-```
-
-Therefore, each Newton step is given by
-```math
-r_{n+1} = r_n + {(1 - \mathcal{R}_0 G(r)) G(r) \over G'(r)}.
+r_{n+1} = r_n - {\mathcal{R}_0 G(r) - 1\over \mathcal{R}_0 G'(r)}.
 ```
 
 =#

--- a/EpiAware/test/test_models.jl
+++ b/EpiAware/test/test_models.jl
@@ -28,14 +28,90 @@
     # Underlying log-infections are const value 1 for all time steps and
     # any other unfixed parameters
 
-    fixed_test_mdl = fix(
-        test_mdl,
-        (init_rw_value = log(1.0), σ²_RW = 0.0, neg_bin_cluster_factor = 0.05),
-    )
+    fixed_test_mdl =
+        fix(test_mdl, (init = log(1.0), σ²_RW = 0.0, neg_bin_cluster_factor = 0.05))
     X = rand(fixed_test_mdl)
     expected_I_t = [1.0 for _ = 1:epimodel.data.time_horizon]
     gen = generated_quantities(fixed_test_mdl, rand(fixed_test_mdl))
 
     # Perform tests
+    @test gen.I_t ≈ expected_I_t
+end
+
+@testitem "exp growth with RW latent process" begin
+    using Distributions, Turing, DynamicPPL
+    # Define test inputs
+    y_t = missing # Data will be generated from the model
+    data = EpiData([0.2, 0.3, 0.5], [0.1, 0.4, 0.5], 0.8, 10, exp)
+    latent_process_priors = default_rw_priors()
+    transform_function = exp
+    n_generate_ahead = 0
+    pos_shift = 1e-6
+    neg_bin_cluster_factor = 0.5
+    neg_bin_cluster_factor_prior = Gamma(3, 0.05 / 3)
+
+    epimodel = ExpGrowthRate(data)
+
+    # Call the function
+    test_mdl = make_epi_inference_model(
+        y_t,
+        epimodel,
+        random_walk;
+        latent_process_priors,
+        pos_shift,
+        neg_bin_cluster_factor,
+        neg_bin_cluster_factor_prior,
+    )
+
+    # Define expected outputs for a conditional model
+    # Underlying log-infections are const value 1 for all time steps and
+    # any other unfixed parameters
+
+    fixed_test_mdl =
+        fix(test_mdl, (init = log(1.0), σ²_RW = 0.0, neg_bin_cluster_factor = 0.05))
+    X = rand(fixed_test_mdl)
+    expected_I_t = [1.0 for _ = 1:epimodel.data.time_horizon]
+    gen = generated_quantities(fixed_test_mdl, rand(fixed_test_mdl))
+
+    # # Perform tests
+    @test gen.I_t ≈ expected_I_t
+end
+
+@testitem "Renewal with RW latent process" begin
+    using Distributions, Turing, DynamicPPL
+    # Define test inputs
+    y_t = missing # Data will be generated from the model
+    data = EpiData([0.2, 0.3, 0.5], [0.1, 0.4, 0.5], 0.8, 10, exp)
+    latent_process_priors = default_rw_priors()
+    transform_function = exp
+    n_generate_ahead = 0
+    pos_shift = 1e-6
+    neg_bin_cluster_factor = 0.5
+    neg_bin_cluster_factor_prior = Gamma(3, 0.05 / 3)
+
+    epimodel = Renewal(data)
+
+    # Call the function
+    test_mdl = make_epi_inference_model(
+        y_t,
+        epimodel,
+        random_walk;
+        latent_process_priors,
+        pos_shift,
+        neg_bin_cluster_factor,
+        neg_bin_cluster_factor_prior,
+    )
+
+    # Define expected outputs for a conditional model
+    # Underlying log-infections are const value 1 for all time steps and
+    # any other unfixed parameters
+
+    fixed_test_mdl =
+        fix(test_mdl, (init = log(1.0), σ²_RW = 0.0, neg_bin_cluster_factor = 0.05))
+    X = rand(fixed_test_mdl)
+    expected_I_t = [1.0 for _ = 1:epimodel.data.time_horizon]
+    gen = generated_quantities(fixed_test_mdl, rand(fixed_test_mdl))
+
+    # # Perform tests
     @test gen.I_t ≈ expected_I_t
 end

--- a/EpiAware/test/test_utilities.jl
+++ b/EpiAware/test/test_utilities.jl
@@ -82,6 +82,7 @@ end
 end
 
 @testitem "Testing growth_rate_to_reproductive_ratio function" begin
+    using EpiAware
     #Test that zero exp growth rate imples R0 = 1
     @testset "Test case 1" begin
         r = 0
@@ -116,6 +117,54 @@ end
         )
         K = generate_observation_kernel(delay_int, time_horizon)
         @test K == expected_K
+    end
+
+end
+@testitem "Testing neg_MGF function" begin
+    # Test case 1: Testing with positive r and non-empty weight vector
+    @testset "Test case 1" begin
+        r = 0.5
+        w = [0.2, 0.3, 0.5]
+        expected_result = 0.2 * exp(-0.5 * 1) + 0.3 * exp(-0.5 * 2) + 0.5 * exp(-0.5 * 3)
+        result = neg_MGF(r, w)
+        @test result ≈ expected_result atol = 1e-15
+    end
+
+    # Test case 2: Testing with zero r and non-empty weight vector
+    @testset "Test case 2" begin
+        r = 0
+        w = [0.1, 0.2, 0.3, 0.4]
+        expected_result =
+            0.1 * exp(-0 * 1) + 0.2 * exp(-0 * 2) + 0.3 * exp(-0 * 3) + 0.4 * exp(-0 * 4)
+        result = neg_MGF(r, w)
+        @test result ≈ expected_result atol = 1e-15
+    end
+
+end
+
+@testitem "Testing dneg_MGF_dr function" begin
+    # Test case 1: Testing with positive r and non-empty weight vector
+    @testset "Test case 1" begin
+        r = 0.5
+        w = [0.2, 0.3, 0.5]
+        expected_result =
+            -(0.2 * 1 * exp(-0.5 * 1) + 0.3 * 2 * exp(-0.5 * 2) + 0.5 * 3 * exp(-0.5 * 3))
+        result = dneg_MGF_dr(r, w)
+        @test result ≈ expected_result atol = 1e-15
+    end
+
+    # Test case 2: Testing with zero r and non-empty weight vector
+    @testset "Test case 2" begin
+        r = 0
+        w = [0.1, 0.2, 0.3, 0.4]
+        expected_result = -(
+            0.1 * 1 * exp(-0 * 1) +
+            0.2 * 2 * exp(-0 * 2) +
+            0.3 * 3 * exp(-0 * 3) +
+            0.4 * 4 * exp(-0 * 4)
+        )
+        result = dneg_MGF_dr(r, w)
+        @test result ≈ expected_result atol = 1e-15
     end
 
 end


### PR DESCRIPTION
This PR is for creating an appropriate initialisation for inference. In practice, this applies to the renewal model approach encapsulated by the `Renewal` model.

#### Major changes

- An new expectation is that any latent process model should pass an `init` kw value and this can have its own priors e.g. here:
https://github.com/CDCgov/Rt-without-renewal/blob/dece834bbbdba185d4e10282c250d1a6ff8dc18c/EpiAware/src/latent-processes.jl#L17-L24
- The callable function associated with an object which is a subtype of `AbstractEpiModel` is now fixed as defining the latent process -> infections transformation. Before it defined an updating function to be used by `scan`; however that was not the natural approach in (say) direct infection modelling. Instances of `Renewal` model now use `scan` under the hood. eg here:
https://github.com/CDCgov/Rt-without-renewal/blob/dece834bbbdba185d4e10282c250d1a6ff8dc18c/EpiAware/src/models.jl#L15-L19
- This change means that initialisation is also dealt with by the callable function. The only complex one is for `Renewal` [here](https://github.com/CDCgov/Rt-without-renewal/blob/dece834bbbdba185d4e10282c250d1a6ff8dc18c/EpiAware/src/epimodel.jl#L79C1-L93C4).
- For `Renewal` initialisation is done by treating `init` as defining a time zero incidence. The pre-time zero incidence is backwards exponential with the exponential growth rate implied by `R_t[1]` from the latent process and the GI. Note that this matches @dylanhmorris [here](https://github.com/cdcent/cfa-stf-team-materials/discussions/24). The difference is I use a quick Newton method with an informed guess to do the $\mathcal{R}_0$ to $r$ transformation; this is faster than using a generic root finder because you can solve the structure of the problem [here](https://github.com/CDCgov/Rt-without-renewal/blob/999bd8e2bfdd108a63216fca0c7de908e07a6c70/EpiAware/src/utilities.jl#L133C1-L146C4) and gets to high accuracy in a couple of steps: evidence [here](https://github.com/CDCgov/Rt-without-renewal/blob/40-initialisation-infection-generation-processes/EpiAware/test/predictive_checking/fast_approx_for_r.jl).

#### Minor change

- I've changed an `Aqua` kwarg to `persistent_tasks = false` because locally a Turing extension was precompiling out of sequence (TBD to burrow into that).

