### PR TITLE
Reduce number of exported functions

### DIFF
--- a/EpiAware/src/EpiAware.jl
+++ b/EpiAware/src/EpiAware.jl
@@ -31,18 +31,10 @@ using Distributions,
     QuadGK
 
 # Exported utilities
-export scan,
-    create_discrete_pmf,
-    growth_rate_to_reproductive_ratio,
-    generate_observation_kernel,
-    default_rw_priors,
-    default_delay_obs_priors,
-    neg_MGF,
-    dneg_MGF_dr,
-    R_to_r
+export create_discrete_pmf, default_rw_priors, default_delay_obs_priors
 
 # Exported types
-export EpiData, Renewal, ExpGrowthRate, DirectInfections, AbstractEpiModel
+export EpiData, Renewal, ExpGrowthRate, DirectInfections
 
 # Exported Turing model constructors
 export make_epi_inference_model, random_walk, delay_observations

--- a/EpiAware/test/predictive_checking/fast_approx_for_r.jl
+++ b/EpiAware/test/predictive_checking/fast_approx_for_r.jl
@@ -29,10 +29,17 @@ To rapidly improve the estimate for `r` we use Newton steps given by
 r_{n+1} = r_n - {\mathcal{R}_0 G(r) - 1\over \mathcal{R}_0 G'(r)}.
 ```
 
-=#
+### Test mode
 
+Run this script in Test environment mode. If not, run the following command:
+
+```julia
 using TestEnv
 TestEnv.activate()
+```
+=#
+
+
 using EpiAware
 using Distributions
 using StatsPlots
@@ -52,10 +59,10 @@ doubling_times = [1.0, 3.5, 7.0, 14.0]
 
 errors = mapreduce(hcat, doubling_times) do T_2
     true_r = log(2) / T_2 # 7 day doubling time
-    R0 = growth_rate_to_reproductive_ratio(true_r, w)
+    R0 = EpiAware.growth_rate_to_reproductive_ratio(true_r, w)
 
     return map(idxs) do ns
-        @time r = R_to_r(R0, w, newton_steps = ns)
+        @time r = EpiAware.R_to_r(R0, w, newton_steps = ns)
         abs(r - true_r) + jitter
     end
 end

--- a/EpiAware/test/predictive_checking/toy_model_log_infs_RW.jl
+++ b/EpiAware/test/predictive_checking/toy_model_log_infs_RW.jl
@@ -48,14 +48,14 @@ r &\sim \text{Gamma}(3, 0.05/3).
 
 ## Load dependencies
 
-This script should be run from the root folder of `EpiAware` and with the active environment.
+This script should be run from Test environment mode. If not, run the following command:
 
-=#
-
-
-
+```julia
 using TestEnv # Run in Test environment mode
 TestEnv.activate()
+```
+
+=#
 
 using EpiAware
 using Turing

--- a/EpiAware/test/test_utilities.jl
+++ b/EpiAware/test/test_utilities.jl
@@ -7,7 +7,7 @@
     xs = [1, 2, 3, 4, 5]
     expected_ys = [1, 3, 6, 10, 15]
     expected_carry = 15
-    ys, carry = scan(add, 0, xs)
+    ys, carry = EpiAware.scan(add, 0, xs)
     @test ys == expected_ys
     @test carry == expected_carry
 end
@@ -22,7 +22,7 @@ end
     expected_ys = [1, 2, 6, 24, 120]
     expected_carry = 120
 
-    ys, carry = scan(multiply, 1, xs)
+    ys, carry = EpiAware.scan(multiply, 1, xs)
     @test ys == expected_ys
     @test carry == expected_carry
 end
@@ -87,7 +87,7 @@ end
         r = 0
         w = ones(5) |> x -> x ./ sum(x)
         expected_ratio = 1
-        ratio = growth_rate_to_reproductive_ratio(r, w)
+        ratio = EpiAware.growth_rate_to_reproductive_ratio(r, w)
         @test ratio ≈ expected_ratio atol = 1e-15
     end
 
@@ -95,7 +95,7 @@ end
     @testset "Test case 2" begin
         r = 0
         w = 1
-        @test_throws MethodError growth_rate_to_reproductive_ratio(r, w)
+        @test_throws MethodError EpiAware.growth_rate_to_reproductive_ratio(r, w)
     end
 
 end
@@ -114,7 +114,7 @@ end
                 0 0 0.3 0.5 0.2
             ],
         )
-        K = generate_observation_kernel(delay_int, time_horizon)
+        K = EpiAware.generate_observation_kernel(delay_int, time_horizon)
         @test K == expected_K
     end
 
@@ -126,7 +126,7 @@ end
         r = 0.5
         w = [0.2, 0.3, 0.5]
         expected_result = 0.2 * exp(-0.5 * 1) + 0.3 * exp(-0.5 * 2) + 0.5 * exp(-0.5 * 3)
-        result = neg_MGF(r, w)
+        result = EpiAware.neg_MGF(r, w)
         @test result ≈ expected_result atol = 1e-15
     end
 
@@ -136,20 +136,21 @@ end
         w = [0.1, 0.2, 0.3, 0.4]
         expected_result =
             0.1 * exp(-0 * 1) + 0.2 * exp(-0 * 2) + 0.3 * exp(-0 * 3) + 0.4 * exp(-0 * 4)
-        result = neg_MGF(r, w)
+        result = EpiAware.neg_MGF(r, w)
         @test result ≈ expected_result atol = 1e-15
     end
 
 end
 
 @testitem "Testing dneg_MGF_dr function" begin
+
     # Test case 1: Testing with positive r and non-empty weight vector
     @testset "Test case 1" begin
         r = 0.5
         w = [0.2, 0.3, 0.5]
         expected_result =
             -(0.2 * 1 * exp(-0.5 * 1) + 0.3 * 2 * exp(-0.5 * 2) + 0.5 * 3 * exp(-0.5 * 3))
-        result = dneg_MGF_dr(r, w)
+        result = EpiAware.dneg_MGF_dr(r, w)
         @test result ≈ expected_result atol = 1e-15
     end
 
@@ -163,7 +164,7 @@ end
             0.3 * 3 * exp(-0 * 3) +
             0.4 * 4 * exp(-0 * 4)
         )
-        result = dneg_MGF_dr(r, w)
+        result = EpiAware.dneg_MGF_dr(r, w)
         @test result ≈ expected_result atol = 1e-15
     end
 


### PR DESCRIPTION
All functions were being exported by `EpiAware`. Following discussion, in particular #46 , I've decided to expose _only_ functions that:

- Define the model (defined as latent process, latent process to infections function, observation process, their priors).
- Are going to be used in inference.

This PR is my first pass on this. Tests for internal functions have `EpiAware.my_function` as prefix in the `test` folder.

closes #46 