### PR TITLE
Refactor with method hierarchy

### DIFF
--- a/EpiAware/src/EpiAware.jl
+++ b/EpiAware/src/EpiAware.jl
@@ -20,28 +20,28 @@ This module provides functionality for calculating Rt (effective reproduction nu
 module EpiAware
 
 using Distributions,
-    Turing,
-    LogExpFunctions,
-    LinearAlgebra,
-    SparseArrays,
-    Random,
-    ReverseDiff,
-    Optim,
-    Parameters,
-    QuadGK,
-    DataFramesMeta
+      Turing,
+      LogExpFunctions,
+      LinearAlgebra,
+      SparseArrays,
+      Random,
+      ReverseDiff,
+      Optim,
+      Parameters,
+      QuadGK,
+      DataFramesMeta
 
 # Exported utilities
 export create_discrete_pmf,
-    default_rw_priors, default_delay_obs_priors,
-    default_initialisation_prior, spread_draws
+       default_rw_priors, default_delay_obs_priors,
+       default_initialisation_prior, spread_draws
 
 # Exported types
 export EpiData, Renewal, ExpGrowthRate, DirectInfections
 
 # Exported Turing model constructors
 export make_epi_inference_model, delay_observations_model,
-    initialize_incidence
+       initialize_incidence
 
 include("epimodel.jl")
 include("utilities.jl")

--- a/EpiAware/src/models.jl
+++ b/EpiAware/src/models.jl
@@ -5,7 +5,8 @@
         observation_model::AbstractObservationModel,
         pos_shift = 1e-6)
     #Latent process
-    @submodel latent_process, latent_process_aux = generate_latent_process(latent_process_model,
+    @submodel latent_process, latent_process_aux = generate_latent_process(
+        latent_process_model,
         time_steps)
 
     #Transform into infections

--- a/EpiAware/test/test_utilities.jl
+++ b/EpiAware/test/test_utilities.jl
@@ -64,7 +64,7 @@ end
     @testset "Test case 5" begin
         dist = Exponential(1.0)
         expected_pmf_uncond = [exp(-1)
-            [(1 - exp(-1)) * (exp(1) - 1) * exp(-s) for s in 1:9]]
+                               [(1 - exp(-1)) * (exp(1) - 1) * exp(-s) for s in 1:9]]
         expected_pmf = expected_pmf_uncond ./ sum(expected_pmf_uncond)
         pmf = create_discrete_pmf(dist; Δd = 1.0, D = 10.0)
         @test expected_pmf≈pmf atol=1e-15
@@ -100,10 +100,10 @@ end
         delay_int = [0.2, 0.5, 0.3]
         time_horizon = 5
         expected_K = SparseMatrixCSC([0.2 0 0 0 0
-            0.5 0.2 0 0 0
-            0.3 0.5 0.2 0 0
-            0 0.3 0.5 0.2 0
-            0 0 0.3 0.5 0.2])
+                                      0.5 0.2 0 0 0
+                                      0.3 0.5 0.2 0 0
+                                      0 0.3 0.5 0.2 0
+                                      0 0 0.3 0.5 0.2])
         K = EpiAware.generate_observation_kernel(delay_int, time_horizon)
         @test K == expected_K
     end


### PR DESCRIPTION
This is a draft PR that implements an alternative workflow (building on that discussed in #75) which uses multiple dispatch to allow use of both a struct and a function that takes arguments. 

Implementation:

https://github.com/CDCgov/Rt-without-renewal/blob/refactor-struct-to-arg/EpiAware/src/latent-processes.jl


See example use: 

```julia
priors = default_rw_priors()
n = 10  # Number of steps in the random walk

# Directly using the tag-based dispatch
latent_rw = latent_process(RandomWalkLatentProcessArg(), n, var_prior = truncated(Normal(0.0, 0.05), 0.0, Inf),
	init_prior = Normal())

# Create a RandomWalkLatentProcess instance with priors
rw_lp = RandomWalkLatentProcess(priors[:init_rw_value_prior], priors[:var_RW_prior])

# Using the struct-based dispatch
latent_rw_struct = latent_process(rw_lp, n)

# Attempting to call with a generic AbstractLatentProcess
latent_process(AbstractLatentProcess(), n)

# Attempting to call with a generic AbstractLatentProcessArg
latent_process(AbstractLatentProcessArg(), n)
```

## Con

- Adds an additional method that needs to be defined
- May not be a standard approach
- Leads to a slightly more complex stack trace
- Has no code impact for our use case

## Plus

- Can document the arguments in the funciton docs and then link out to the struct that carries them
- May make resuse of low level functions easier
- Increases code modularity (?)