### PR TITLE
Issue 118: First pass at missing data support

### DIFF
--- a/EpiAware/docs/src/examples/getting_started.jl
+++ b/EpiAware/docs/src/examples/getting_started.jl
@@ -239,7 +239,24 @@ We do the inference by MCMC/NUTS using the `Turing` NUTS sampler with default wa
 # ╔═╡ c8ce0d46-a160-4c40-a055-69b3d10d1770
 truth_data = generated_obs
 
+# ╔═╡ 4a4c6e91-8d8f-4bbf-bb7e-a36dc281e312
+md"
+The observation model supports partially complete data. To test this we set some of the generated observations to be `missing`.
+"
+
+# ╔═╡ 259a7042-e74f-43c7-aeb4-97a3beeb7776
+let
+    truth_data = Union{Int, Missing}[truth_data...]
+    truth_data[vcat([3, 5], 10:20)] .= missing
+end
+
+# ╔═╡ 32638954-2c99-4d4e-8e03-52154030c657
+md"
+We now make the model but fixing the initial condition of the random walk to be 0.
+"
+
 # ╔═╡ b4033728-b321-4100-8194-1fd9fe2d268d
+
 inference_mdl = fix(
     make_epi_aware(truth_data, time_horizon; epi_model = epi_model,
         latent_model = rwp, observation_model = obs_model),
@@ -296,6 +313,8 @@ let
         layout = (1, 2),
         size = (700, 400))
 end
+
+# ╔═╡ 2293b711-0bd0-44d5-8a30-94e56c5e4c65
 
 # ╔═╡ fd6321b1-4c3a-4123-b0dc-c45b951e0b80
 md"
@@ -382,12 +401,16 @@ end
 # ╠═d073e63b-62da-4743-ace0-78ef7806bc0b
 # ╠═a04f3c1b-7e11-4800-9c2a-9fc0021de6e7
 # ╟─f68b4e41-ac5c-42cd-a8c2-8761d66f7543
-# ╟─b5bc8f05-b538-4abf-aa84-450bf2dff3d9
+# ╠═b5bc8f05-b538-4abf-aa84-450bf2dff3d9
 # ╠═c8ce0d46-a160-4c40-a055-69b3d10d1770
+# ╟─4a4c6e91-8d8f-4bbf-bb7e-a36dc281e312
+# ╠═259a7042-e74f-43c7-aeb4-97a3beeb7776
+# ╟─32638954-2c99-4d4e-8e03-52154030c657
 # ╠═b4033728-b321-4100-8194-1fd9fe2d268d
 # ╠═3eb5ec5e-aae7-478e-84fb-80f2e9f85b4c
 # ╟─30498cc7-16a5-441a-b8cd-c19b220c60c1
 # ╠═e9df22b8-8e4d-4ab7-91ea-c01f2239b3e5
+# ╠═2293b711-0bd0-44d5-8a30-94e56c5e4c65
 # ╟─fd6321b1-4c3a-4123-b0dc-c45b951e0b80
 # ╠═10d8fe24-83a6-47ac-97b7-a374481473d3
 # ╟─81efe8ca-b753-4a12-bafc-a887a999377b

--- a/EpiAware/docs/src/examples/getting_started.jl
+++ b/EpiAware/docs/src/examples/getting_started.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.40
+# v0.19.39
 
 using Markdown
 using InteractiveUtils
@@ -213,6 +213,9 @@ random_epidemic = rand(cond_generative_model)
 # ╔═╡ d073e63b-62da-4743-ace0-78ef7806bc0b
 true_infections = generated_quantities(cond_generative_model, random_epidemic).I_t
 
+# ╔═╡ a04f3c1b-7e11-4800-9c2a-9fc0021de6e7
+generated_obs = generated_quantities(cond_generative_model, random_epidemic).generated_y_t
+
 # ╔═╡ f68b4e41-ac5c-42cd-a8c2-8761d66f7543
 let
     plot(true_infections,
@@ -220,7 +223,7 @@ let
         xlabel = "Time",
         ylabel = "Infections",
         title = "Generated Infections")
-    scatter!(random_epidemic.y_t, lab = "generated cases")
+    scatter!(generated_obs, lab = "generated cases")
 end
 
 # ╔═╡ b5bc8f05-b538-4abf-aa84-450bf2dff3d9
@@ -234,7 +237,7 @@ We do the inference by MCMC/NUTS using the `Turing` NUTS sampler with default wa
 "
 
 # ╔═╡ c8ce0d46-a160-4c40-a055-69b3d10d1770
-truth_data = random_epidemic.y_t
+truth_data = generated_obs
 
 # ╔═╡ b4033728-b321-4100-8194-1fd9fe2d268d
 inference_mdl = fix(
@@ -377,6 +380,7 @@ end
 # ╠═7e0e6012-8648-4f84-a25a-8b0138c4b72a
 # ╠═b20c28be-7b07-410c-a33b-ea5ad6828c12
 # ╠═d073e63b-62da-4743-ace0-78ef7806bc0b
+# ╠═a04f3c1b-7e11-4800-9c2a-9fc0021de6e7
 # ╟─f68b4e41-ac5c-42cd-a8c2-8761d66f7543
 # ╟─b5bc8f05-b538-4abf-aa84-450bf2dff3d9
 # ╠═c8ce0d46-a160-4c40-a055-69b3d10d1770

--- a/EpiAware/src/observation-models.jl
+++ b/EpiAware/src/observation-models.jl
@@ -41,48 +41,22 @@ end
         y_t,
         I_t;
         pos_shift)
+
     #Parameters
     neg_bin_cluster_factor ~ observation_model.neg_bin_cluster_factor_prior
 
     #Predictive distribution
     expected_obs = observation_model.delay_kernel * I_t .+ pos_shift
 
-    if should_vectorize(y_t)
-        y_t ~ arraydist(NegativeBinomialMeanClust.(expected_obs, neg_bin_cluster_factor))
-    else
-        for i in eachindex(y_t)
-            y_t[i] ~ NegativeBinomialMeanClust(expected_obs[i], neg_bin_cluster_factor)
-        end
+    if ismissing(y_t)
+        y_t = Vector{Float64}(undef, length(expected_obs))
+    end
+
+    for i in eachindex(y_t)
+        y_t[i] ~ NegativeBinomialMeanClust(
+            expected_obs[i], neg_bin_cluster_factor
+        )
     end
 
     return y_t, (; neg_bin_cluster_factor,)
-end
-
-"""
-    should_vectorize(y_t)
-
-Determine whether the input `y_t` should be processed in a vectorized manner.
-This is determined based on whether `y_t` is completely missing or if it is an array
-with no missing values (vectorized processing is preferred) versus being an array with
-some missing values (non-vectorized, individual processing is necessary).
-
-# Arguments
-- `y_t`: The input data which can be a scalar, vector, or `missing`.
-
-# Returns
-- `Boolean`: `true` if `y_t` should be processed in a vectorized manner, `false` otherwise.
-"""
-function should_vectorize(y_t)
-    # Check if y_t is entirely missing, which implies non-vectorized processing
-    if ismissing(y_t)
-        return false
-    end
-
-    # If y_t is an array, check for any missing elements
-    if isa(y_t, AbstractArray)
-        return !any(ismissing, y_t)
-    end
-
-    # For all other cases, including scalar non-missing values, prefer vectorized processing
-    return true
 end

--- a/EpiAware/src/observation-models.jl
+++ b/EpiAware/src/observation-models.jl
@@ -49,7 +49,7 @@ end
     expected_obs = observation_model.delay_kernel * I_t .+ pos_shift
 
     if ismissing(y_t)
-        y_t = Vector{Float64}(undef, length(expected_obs))
+        y_t = Vector{Int}(undef, length(expected_obs))
     end
 
     for i in eachindex(y_t)

--- a/EpiAware/src/utilities.jl
+++ b/EpiAware/src/utilities.jl
@@ -196,7 +196,7 @@ function r_to_R(r, w::AbstractVector)
 end
 
 """
-    mean_cc_neg_bin(μ, α)
+    NegativeBinomialMeanClust(μ, α)
 
 Compute the mean-cluster factor negative binomial distribution.
 
@@ -207,7 +207,7 @@ Compute the mean-cluster factor negative binomial distribution.
 # Returns
 A `NegativeBinomial` distribution object.
 """
-function mean_cc_neg_bin(μ, α)
+function NegativeBinomialMeanClust(μ, α)
     ex_σ² = (α * μ^2) + 1e-6
     p = μ / (μ + ex_σ² + 1e-6)
     r = μ^2 / ex_σ²

--- a/EpiAware/test/test_models.jl
+++ b/EpiAware/test/test_models.jl
@@ -32,7 +32,7 @@
     gen = generated_quantities(test_mdl, rand(test_mdl))
 
     #Check model sampled
-    @test eltype(gen.generated_y_t) <: AbstractFloat
+    @test eltype(gen.generated_y_t) <: Int
     @test eltype(gen.I_t) <: AbstractFloat
     @test length(gen.I_t) == time_horizon
 end
@@ -71,7 +71,7 @@ end
     gens = generated_quantities(test_mdl, chn)
 
     #Check model sampled
-    @test eltype(gens[1].generated_y_t) <: AbstractFloat
+    @test eltype(gens[1].generated_y_t) <: Int
     @test eltype(gens[1].I_t) <: AbstractFloat
     @test length(gens[1].I_t) == time_horizon
 end
@@ -110,7 +110,7 @@ end
     gens = generated_quantities(test_mdl, chn)
 
     #Check model sampled
-    @test eltype(gens[1].generated_y_t) <: AbstractFloat
+    @test eltype(gens[1].generated_y_t) <: Int
     @test eltype(gens[1].I_t) <: AbstractFloat
     @test length(gens[1].I_t) == time_horizon
 end

--- a/EpiAware/test/test_models.jl
+++ b/EpiAware/test/test_models.jl
@@ -32,7 +32,7 @@
     gen = generated_quantities(test_mdl, rand(test_mdl))
 
     #Check model sampled
-    @test eltype(gen.generated_y_t) <: Integer
+    @test eltype(gen.generated_y_t) <: AbstractFloat
     @test eltype(gen.I_t) <: AbstractFloat
     @test length(gen.I_t) == time_horizon
 end
@@ -71,7 +71,7 @@ end
     gens = generated_quantities(test_mdl, chn)
 
     #Check model sampled
-    @test eltype(gens[1].generated_y_t) <: Integer
+    @test eltype(gens[1].generated_y_t) <: AbstractFloat
     @test eltype(gens[1].I_t) <: AbstractFloat
     @test length(gens[1].I_t) == time_horizon
 end
@@ -110,7 +110,7 @@ end
     gens = generated_quantities(test_mdl, chn)
 
     #Check model sampled
-    @test eltype(gens[1].generated_y_t) <: Integer
+    @test eltype(gens[1].generated_y_t) <: AbstractFloat
     @test eltype(gens[1].I_t) <: AbstractFloat
     @test length(gens[1].I_t) == time_horizon
 end

--- a/EpiAware/test/test_observation-models.jl
+++ b/EpiAware/test/test_observation-models.jl
@@ -65,7 +65,7 @@ end
                 delay_obs, y_t_scenario, I_t; pos_shift = pos_shift)
 
             sampled_obs = sample(mdl, NUTS(), MCMCThreads(), 250, 2; drop_warmup = true) |>
-                          chn -> generated_quantities(fix_mdl, chn) .|>
+                          chn -> generated_quantities(mdl, chn) .|>
                                  (gen -> gen[1]) |>
                                  collect
 

--- a/EpiAware/test/test_observation-models.jl
+++ b/EpiAware/test/test_observation-models.jl
@@ -53,10 +53,8 @@ end
     delay_obs = EpiAware.DelayObservations(
         [1.0], length(I_t), obs_prior[:neg_bin_cluster_factor_prior])
     neg_bin_cf = 0.05  # Set up priors
-
     # Expected point estimate calculation setup
     pos_shift = 1e-6
-    expected_obs_calculation = (I_t_val) -> I_t_val + pos_shift  # Simplified example
 
     # Test each y_t scenario
     for (scenario_name, y_t_scenario) in [("fully observed", y_t_fully_observed),


### PR DESCRIPTION
This PR adds support for missing data in the observation model by moving from a vectorised to loop approach. It also renames the negative binomial observation model to match the distribution naming scheme. 