### PR TITLE
rename `latent_model_model` to `latent_model`

### DIFF
--- a/EpiAware/src/models.jl
+++ b/EpiAware/src/models.jl
@@ -1,16 +1,16 @@
 @model function make_epi_aware(y_t,
         time_steps;
         epi_model::AbstractEpiModel,
-        latent_model_model::AbstractLatentModel,
+        latent_model::AbstractLatentModel,
         observation_model::AbstractObservationModel,
         pos_shift = 1e-6)
     #Latent process
-    @submodel latent_model, latent_model_aux = generate_latent(
-        latent_model_model,
+    @submodel Z_t, latent_model_aux = generate_latent(
+        latent_model,
         time_steps)
 
     #Transform into infections
-    @submodel I_t = generate_latent_infs(epi_model, latent_model)
+    @submodel I_t = generate_latent_infs(epi_model, Z_t)
 
     #Predictive distribution of ascerted cases
     @submodel generated_y_t, generated_y_t_aux = generate_observations(observation_model,

--- a/EpiAware/test/test_models.jl
+++ b/EpiAware/test/test_models.jl
@@ -27,7 +27,7 @@
 
     # Create full epi model and sample from it
     test_mdl = make_epi_aware(y_t, time_horizon; epi_model = epi_model,
-        latent_model_model = rwp,
+        latent_model = rwp,
         observation_model = obs_model, pos_shift)
     gen = generated_quantities(test_mdl, rand(test_mdl))
 
@@ -63,7 +63,7 @@ end
     test_mdl = make_epi_aware(y_t,
         time_horizon;
         epi_model = epi_model,
-        latent_model_model = rwp,
+        latent_model = rwp,
         observation_model = obs_model,
         pos_shift)
 
@@ -102,7 +102,7 @@ end
     test_mdl = make_epi_aware(y_t,
         time_horizon;
         epi_model = epi_model,
-        latent_model_model = rwp,
+        latent_model = rwp,
         observation_model = obs_model,
         pos_shift)
 


### PR DESCRIPTION
This PR fixes #111 .

`latent_model_model` goes to `latent_model` as a keyword argument. Internal use of _realisations_ of the latent model are denoted `Z_t`.