### PR TITLE
Remove attempt to detect `fieldnames` for functions which lead to error

### DIFF
--- a/EpiAware/docs/make.jl
+++ b/EpiAware/docs/make.jl
@@ -7,7 +7,7 @@ include("pages.jl")
 makedocs(; sitename = "EpiAware.jl",
     authors = "Samuel Brand, Zachary Susswein, Sam Abbott, and contributors",
     clean = true, doctest = true, linkcheck = true,
-    warnonly = [:docs_block, :missing_docs],
+    warnonly = [:docs_block, :missing_docs, :linkcheck],
     modules = [EpiAware],
     pages = pages,
     format = Documenter.HTML(

--- a/EpiAware/src/docstrings.jl
+++ b/EpiAware/src/docstrings.jl
@@ -8,9 +8,6 @@
                                          ---
                                          ## Methods
                                          $(METHODLIST)
-                                         ---
-                                         ## Fields
-                                         $(TYPEDFIELDS)
                                          """
 
 @template (TYPES) = """


### PR DESCRIPTION
This aims to fix #108 .

The problem appears to be that we were setting a document `@template` for function, methods and macros which included fieldnames. Those objects don't have fieldnames, so this was chucking an error (this really should be a warning IMO...).