### PR TITLE
188 using prefix to separate latent random variables used in different contexts

### DIFF
--- a/EpiAware/docs/src/examples/getting_started.jl
+++ b/EpiAware/docs/src/examples/getting_started.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.39
+# v0.19.41
 
 using Markdown
 using InteractiveUtils
@@ -505,7 +505,7 @@ We can interrogate the sampled chains directly from the `samples` field of the `
 
 # ╔═╡ ff21c9ec-1581-405f-8db1-0f522b5bc296
 let
-    p1 = histogram(inference_results.samples[:cluster_factor],
+    p1 = histogram(inference_results.samples["obs.cluster_factor"],
         lab = "chain " .* string.([1 2 3 4]),
         fillalpha = 0.4,
         lw = 0,
@@ -527,7 +527,7 @@ let
         c = :black,
         lab = "prior")
 
-    p3 = histogram(inference_results.samples["damp_AR[1]"],
+    p3 = histogram(inference_results.samples["latent.damp_AR[1]"],
         lab = "chain " .* string.([1 2 3 4]),
         fillalpha = 0.4,
         lw = 0,
@@ -538,7 +538,7 @@ let
         c = :black,
         lab = "prior")
 
-    p4 = histogram(inference_results.samples["damp_AR[2]"],
+    p4 = histogram(inference_results.samples["latent.damp_AR[2]"],
         lab = "chain " .* string.([1 2 3 4]),
         fillalpha = 0.4,
         lw = 0,

--- a/EpiAware/src/EpiAwareUtils/turing-methods.jl
+++ b/EpiAware/src/EpiAwareUtils/turing-methods.jl
@@ -15,13 +15,14 @@ A `DynamicPPPL.Model` object.
         y_t, time_steps, epi_model::AbstractTuringEpiModel;
         latent_model::AbstractTuringLatentModel, observation_model::AbstractTuringObservationModel)
     # Latent process
-    @submodel Z_t, latent_model_aux = generate_latent(latent_model, time_steps)
+    @submodel prefix="latent" Z_t, latent_model_aux=generate_latent(
+        latent_model, time_steps)
 
     # Transform into infections
     @submodel I_t = generate_latent_infs(epi_model, Z_t)
 
     # Predictive distribution of ascertained cases
-    @submodel generated_y_t, generated_y_t_aux = generate_observations(
+    @submodel prefix="obs" generated_y_t, generated_y_t_aux=generate_observations(
         observation_model, y_t, I_t)
 
     # Generate quantities

--- a/EpiAware/src/EpiObsModels/Ascertainment.jl
+++ b/EpiAware/src/EpiObsModels/Ascertainment.jl
@@ -51,7 +51,7 @@ Generates observations based on the `LatentDelay` observation model.
     @submodel expected_obs_mod, expected_aux = generate_latent(
         obs_model.latentmodel, length(Y_t))
 
-    expected_obs = Y_t .* obs_model.link(expected_obs_mod)
+    expected_obs = Y_t .* obs_model.link.(expected_obs_mod)
 
     @submodel y_t, obs_aux = generate_observations(obs_model.model, y_t, expected_obs)
     return y_t, (; expected_obs, expected_obs_mod, expected_aux..., obs_aux...)


### PR DESCRIPTION
This PR fixes the problem mentioned in #188 : That is that different components of a full epi model could both call a latent model leading to naming collision.

The solution is that all latent processes generated to be used in an epi model (for example, $\log R_t$) get sampled with naming prefix form `latent.varname`, whereas latent processes sampled as part of an overall observation model get prefix form `obs.varname`. This is unit tested with a time varying log-ascertainment scale [here](https://github.com/CDCgov/Rt-without-renewal/blob/5aa10e5e06d80fb05cfee578f0a67e677351815f/EpiAware/test/EpiAwareUtils/turing-methods.jl#L70C1-L78C64).

For me, the only open question is whether we want to custom generate prefixes, leave the version in this PR or plan a future issue about custom prefixes (e.g. as part of model struct).

Closes #188 