### PR TITLE
Issue 192: add Identity matrix specification for MvNormal

### DIFF
--- a/EpiAware/src/EpiLatentModels/AR.jl
+++ b/EpiAware/src/EpiLatentModels/AR.jl
@@ -75,7 +75,7 @@ Generate a latent AR series.
 "
 @model function EpiAwareBase.generate_latent(latent_model::AR, n)
     p = latent_model.p
-    ϵ_t ~ MvNormal(ones(n - p))
+    ϵ_t ~ MvNormal(I(n - p))
     σ_AR ~ latent_model.std_prior
     ar_init ~ latent_model.init_prior
     damp_AR ~ latent_model.damp_prior

--- a/EpiAware/src/EpiLatentModels/EpiLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/EpiLatentModels.jl
@@ -7,7 +7,7 @@ using ..EpiAwareBase
 
 using ..EpiAwareUtils: HalfNormal
 
-using Turing, Distributions, DocStringExtensions
+using Turing, Distributions, DocStringExtensions, LinearAlgebra
 
 #Export models
 export RandomWalk, AR, DiffLatentModel, BroadcastLatentModel

--- a/EpiAware/src/EpiLatentModels/RandomWalk.jl
+++ b/EpiAware/src/EpiLatentModels/RandomWalk.jl
@@ -85,7 +85,7 @@ Z_t, _ = generated_quantities(rw_model, θ)
 ```
 "
 @model function EpiAwareBase.generate_latent(latent_model::RandomWalk, n)
-    ϵ_t ~ MvNormal(ones(n))
+    ϵ_t ~ MvNormal(I(n))
     σ_RW ~ latent_model.std_prior
     rw_init ~ latent_model.init_prior
     rw = Vector{eltype(ϵ_t)}(undef, n)


### PR DESCRIPTION
This PR closes #192 by switching to use `LinearAlgebra.I` rather than `ones` in the specification of the `MvNormal`.