### PR TITLE
add DrWatson structure to pipeline and placeholders

### DIFF
--- a/pipeline/Project.toml
+++ b/pipeline/Project.toml
@@ -1,0 +1,7 @@
+name = "pipeline"
+authors = ["Sam Abbott", "Sam Brand", "Zach Susswein"]
+[compat]
+julia = "1.10.2"
+DrWatson = "2.15.0"
+[deps]
+DrWatson = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"

--- a/pipeline/data/Rt_estimates/placeholder.md
+++ b/pipeline/data/Rt_estimates/placeholder.md
@@ -1,0 +1,1 @@
+# placeholder

--- a/pipeline/data/forecasts/placeholder.md
+++ b/pipeline/data/forecasts/placeholder.md
@@ -1,0 +1,1 @@
+# placeholder

--- a/pipeline/data/growth_rate_estimates/placeholder.md
+++ b/pipeline/data/growth_rate_estimates/placeholder.md
@@ -1,0 +1,1 @@
+# placeholder

--- a/pipeline/data/latent_infs_estimates/placeholder.md
+++ b/pipeline/data/latent_infs_estimates/placeholder.md
@@ -1,0 +1,1 @@
+# placeholder

--- a/pipeline/data/truth_sims/placeholder.md
+++ b/pipeline/data/truth_sims/placeholder.md
@@ -1,0 +1,1 @@
+# placeholder

--- a/pipeline/plots/placeholder.md
+++ b/pipeline/plots/placeholder.md
@@ -1,0 +1,1 @@
+# placeholder

--- a/pipeline/scripts/intro.jl
+++ b/pipeline/scripts/intro.jl
@@ -5,15 +5,15 @@ using DrWatson
 include(srcdir("dummy_src_file.jl"))
 
 println(
-"""
-Currently active project is: $(projectname())
+    """
+    Currently active project is: $(projectname())
 
-Path of active project: $(projectdir())
+    Path of active project: $(projectdir())
 
-Have fun with your new project!
+    Have fun with your new project!
 
-You can help us improve DrWatson by opening
-issues on GitHub, submitting feature requests,
-or even opening your own Pull Requests!
-"""
+    You can help us improve DrWatson by opening
+    issues on GitHub, submitting feature requests,
+    or even opening your own Pull Requests!
+    """
 )

--- a/pipeline/scripts/intro.jl
+++ b/pipeline/scripts/intro.jl
@@ -1,0 +1,19 @@
+using DrWatson
+@quickactivate "pipeline"
+
+# Here you may include files from the source directory
+include(srcdir("dummy_src_file.jl"))
+
+println(
+"""
+Currently active project is: $(projectname())
+
+Path of active project: $(projectdir())
+
+Have fun with your new project!
+
+You can help us improve DrWatson by opening
+issues on GitHub, submitting feature requests,
+or even opening your own Pull Requests!
+"""
+)

--- a/pipeline/src/dummy_src_file.jl
+++ b/pipeline/src/dummy_src_file.jl
@@ -1,0 +1,11 @@
+"""
+    dummy_project_function(x, y) → z
+Dummy function for illustration purposes.
+Performs operation:
+```math
+z = x + y
+```
+"""
+function dummy_project_function(x, y)
+    return x + y
+end

--- a/pipeline/test/runtests.jl
+++ b/pipeline/test/runtests.jl
@@ -14,4 +14,4 @@ end
 
 ti = time() - ti
 println("\nTest took total time of:")
-println(round(ti/60, digits = 3), " minutes")
+println(round(ti / 60, digits = 3), " minutes")

--- a/pipeline/test/runtests.jl
+++ b/pipeline/test/runtests.jl
@@ -1,0 +1,17 @@
+using DrWatson, Test
+@quickactivate "pipeline"
+
+# Here you include files using `srcdir`
+# include(srcdir("file.jl"))
+
+# Run test suite
+println("Starting tests")
+ti = time()
+
+@testset "pipeline tests" begin
+    @test 1 == 1
+end
+
+ti = time() - ti
+println("\nTest took total time of:")
+println(round(ti/60, digits = 3), " minutes")


### PR DESCRIPTION
This short PR proposes and adds a `DrWatson` style project as the analysis pipeline. Because this is already a subdir of a github project some of the structure in the default set-up is not required.

Initialisation command used was:

```julia
initialize_project("pipeline";
       authors = ["Sam Abbott", "Sam Brand", "Zach Susswein"],
       force = true,
       git = false,
       add_test = true,
       template = [
           "src",
           "scripts",
           "data",
           "plots",
           "data" => ["truth_sims", "Rt_estimates", "forecasts"]
       ],
       placeholder = true,
)
```

I added placeholders as `placeholder.md` files.