### PR TITLE
Make sure `DiffLatentModel` outputs a `AbstractTuringLatentModel`

### DIFF
--- a/EpiAware/src/EpiLatentModels/DiffLatentModel.jl
+++ b/EpiAware/src/EpiLatentModels/DiffLatentModel.jl
@@ -77,7 +77,8 @@ Z_t
 ```
 
 """
-struct DiffLatentModel{M <: AbstractTuringLatentModel, P <: Distribution}
+struct DiffLatentModel{M <: AbstractTuringLatentModel, P <: Distribution} <:
+       AbstractTuringLatentModel
     "Underlying latent model for the differenced process"
     model::M
     "The prior distribution for the initial latent variables."

--- a/EpiAware/test/EpiLatentModels/DiffLatentModel.jl
+++ b/EpiAware/test/EpiLatentModels/DiffLatentModel.jl
@@ -9,6 +9,7 @@
         @test diff_model.model == model
         @test diff_model.init_prior == arraydist(init_priors)
         @test diff_model.d == 2
+        @test typeof(diff_model) <: AbstractTuringLatentModel
     end
 
     @testset "Testing DiffLatentModel with single prior and d" begin
@@ -19,6 +20,7 @@
         @test diff_model.model == model
         @test diff_model.init_prior == filldist(init_prior, d)
         @test diff_model.d == d
+        @test typeof(diff_model) <: AbstractTuringLatentModel
     end
 end
 


### PR DESCRIPTION
Found a small problem in using `Broadcast` where `DiffLatentModel` wasn't outputting a struct in a type that was expected (e.g. a subtype of `AbstractTuringLatentModel`).

Fixed this and slightly extended the unit tests.