### PR TITLE
Loop over inference configurations script

### DIFF
--- a/pipeline/Project.toml
+++ b/pipeline/Project.toml
@@ -2,6 +2,8 @@ name = "Analysis pipeline"
 authors = ["Sam Abbott", "Sam Brand", "Zach Susswein"]
 
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
 DataFramesMeta = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"

--- a/pipeline/scripts/common_param_values.jl
+++ b/pipeline/scripts/common_param_values.jl
@@ -6,6 +6,7 @@
 
       """)
 
+using EpiAware
 # Common generation interval values
 gi_means = [2.0, 10.0, 20.0];
 gi_stds = [2.0];
@@ -13,8 +14,16 @@ gi_stds = [2.0];
 #Common thread count
 num_threads = min(10, Threads.nthreads());
 
-#True Rt
+#Common inference method
+inference_method = EpiMethod(
+    pre_sampler_steps = [ManyPathfinder(nruns = 4, maxiters = 100)],
+    sampler = NUTSampler(adtype = AutoForwardDiff(),
+        ndraws = 2000,
+        nchains = num_threads,
+        mcmc_parallel = MCMCThreads())
+)
 
+#True Rt
 A = 0.3
 P = 30.0
 ϕ = asin(-0.1 / 0.3) * P / (2 * π)
@@ -23,3 +32,6 @@ true_Rt = vcat(fill(1.1, 2 * 7), fill(2.0, 2 * 7), fill(0.5, 2 * 7),
     fill(1.5, 2 * 7), fill(0.75, 2 * 7), fill(1.1, 6 * 7)) |>
           Rt -> [Rt;
                  [1.0 + A * sin.(2 * π * (t - ϕ) / P) for t in 1:(N - length(Rt))]]
+
+# Common inference tspan: Length of true Rt less three weeks
+inference_tspan = (1, N - 21)

--- a/pipeline/scripts/common_param_values.jl
+++ b/pipeline/scripts/common_param_values.jl
@@ -1,3 +1,11 @@
+@info("""
+      Setting common parameter in `Main` module.
+      ---------------------------------------------
+      Currently active project is: $(projectname())
+      Path of active project: $(projectdir())
+
+      """)
+
 # Common generation interval values
 gi_means = [2.0, 10.0, 20.0];
 gi_stds = [2.0];

--- a/pipeline/scripts/common_param_values.jl
+++ b/pipeline/scripts/common_param_values.jl
@@ -9,3 +9,17 @@
 # Common generation interval values
 gi_means = [2.0, 10.0, 20.0];
 gi_stds = [2.0];
+
+#Common thread count
+num_threads = min(10, Threads.nthreads());
+
+#True Rt
+
+A = 0.3
+P = 30.0
+ϕ = asin(-0.1 / 0.3) * P / (2 * π)
+N = 160
+true_Rt = vcat(fill(1.1, 2 * 7), fill(2.0, 2 * 7), fill(0.5, 2 * 7),
+    fill(1.5, 2 * 7), fill(0.75, 2 * 7), fill(1.1, 6 * 7)) |>
+          Rt -> [Rt;
+                 [1.0 + A * sin.(2 * π * (t - ϕ) / P) for t in 1:(N - length(Rt))]]

--- a/pipeline/scripts/common_param_values.jl
+++ b/pipeline/scripts/common_param_values.jl
@@ -6,22 +6,9 @@
 
       """)
 
-using EpiAware
 # Common generation interval values
 gi_means = [2.0, 10.0, 20.0];
 gi_stds = [2.0];
-
-#Common thread count
-num_threads = min(10, Threads.nthreads());
-
-#Common inference method
-inference_method = EpiMethod(
-    pre_sampler_steps = [ManyPathfinder(nruns = 4, maxiters = 100)],
-    sampler = NUTSampler(adtype = AutoForwardDiff(),
-        ndraws = 2000,
-        nchains = num_threads,
-        mcmc_parallel = MCMCThreads())
-)
 
 #True Rt
 A = 0.3

--- a/pipeline/scripts/common_scenarios.jl
+++ b/pipeline/scripts/common_scenarios.jl
@@ -1,0 +1,38 @@
+using DrWatson
+@quickactivate "Analysis pipeline"
+
+include(srcdir("AnalysisPipeline.jl"))
+include(scriptsdir("common_param_values.jl"))
+
+@info("""
+      Setting up list of inference scenarios.
+      ---------------------------------------------
+      Currently active project is: $(projectname())
+      Path of active project: $(projectdir())
+
+      """)
+
+## Set up the truth Rt and save a plot of it
+# Set up the EpiAware models to use for inference.
+using .AnalysisPipeline, Plots, JLD2, EpiAware, Distributions, ADTypes, AbstractMCMC
+
+#Common priors for initial process and std priors
+transformed_process_init_prior = Normal(0.0, 0.25)
+underlying_std_prior = HalfNormal(1.0)
+
+ar = AR(damp_priors = [Beta(0.5, 0.5)], std_prior = underlying_std_prior,
+    init_priors = [transformed_process_init_prior])
+
+rw = RandomWalk(
+    std_prior = underlying_std_prior, init_prior = transformed_process_init_prior)
+
+diff_ar = DiffLatentModel(; model = ar, init_priors = [transformed_process_init_prior])
+
+wkly_ar, wkly_rw, wkly_diff_ar = [ar, rw, diff_ar] .|>
+                                 model -> BroadcastLatentModel(model, 7, RepeatBlock())
+
+## Parameter settings
+# Rolled out to a vector of inference configurations using `dict_list`.
+sim_configs = Dict(:igp => [DirectInfections, ExpGrowthRate, Renewal],
+    :latent_model => [wkly_ar, wkly_rw, wkly_diff_ar],
+    :gi_mean => gi_means, :gi_std => gi_stds) |> dict_list

--- a/pipeline/scripts/common_scenarios.jl
+++ b/pipeline/scripts/common_scenarios.jl
@@ -31,7 +31,8 @@ diff_ar = DiffLatentModel(; model = ar, init_priors = [transformed_process_init_
 wkly_ar, wkly_rw, wkly_diff_ar = [ar, rw, diff_ar] .|>
                                  model -> BroadcastLatentModel(model, 7, RepeatBlock())
 
-naming_scheme = Dict(wkly_ar => "wkly_ar", wkly_rw => "wkly_rw", wkly_diff_ar => "wkly_diff_ar")
+naming_scheme = Dict(
+    wkly_ar => "wkly_ar", wkly_rw => "wkly_rw", wkly_diff_ar => "wkly_diff_ar")
 
 ## Parameter settings
 # Rolled out to a vector of inference configurations using `dict_list`.

--- a/pipeline/scripts/common_scenarios.jl
+++ b/pipeline/scripts/common_scenarios.jl
@@ -14,11 +14,11 @@ include(scriptsdir("common_param_values.jl"))
 
 ## Set up the truth Rt and save a plot of it
 # Set up the EpiAware models to use for inference.
-using .AnalysisPipeline, Plots, JLD2, EpiAware, Distributions, ADTypes, AbstractMCMC
+using .AnalysisPipeline, Plots, JLD2, EpiAware, Distributions
 
 #Common priors for initial process and std priors
 transformed_process_init_prior = Normal(0.0, 0.25)
-underlying_std_prior = HalfNormal(1.0)
+underlying_std_prior = HalfNormal(0.25)
 
 ar = AR(damp_priors = [Beta(0.5, 0.5)], std_prior = underlying_std_prior,
     init_priors = [transformed_process_init_prior])
@@ -30,6 +30,8 @@ diff_ar = DiffLatentModel(; model = ar, init_priors = [transformed_process_init_
 
 wkly_ar, wkly_rw, wkly_diff_ar = [ar, rw, diff_ar] .|>
                                  model -> BroadcastLatentModel(model, 7, RepeatBlock())
+
+naming_scheme = Dict(wkly_ar => "wkly_ar", wkly_rw => "wkly_rw", wkly_diff_ar => "wkly_diff_ar")
 
 ## Parameter settings
 # Rolled out to a vector of inference configurations using `dict_list`.

--- a/pipeline/scripts/generate_truth_data.jl
+++ b/pipeline/scripts/generate_truth_data.jl
@@ -16,14 +16,6 @@ include(scriptsdir("common_param_values.jl"));
 ## Set up the truth Rt and save a plot of it
 
 using .AnalysisPipeline, Plots, JLD2
-A = 0.3
-P = 30.0
-ϕ = asin(-0.1 / 0.3) * P / (2 * π)
-N = 160
-true_Rt = vcat(fill(1.1, 2 * 7), fill(2.0, 2 * 7), fill(0.5, 2 * 7),
-    fill(1.5, 2 * 7), fill(0.75, 2 * 7), fill(1.1, 6 * 7)) |>
-          Rt -> [Rt;
-                 [1.0 + A * sin.(2 * π * (t - ϕ) / P) for t in 1:(N - length(Rt))]]
 
 plt_Rt = plot(1:N, true_Rt, label = "True Rt", xlabel = "Time", ylabel = "Rt",
     title = "True Rt", legend = :topright);

--- a/pipeline/scripts/inference_pipeline.jl
+++ b/pipeline/scripts/inference_pipeline.jl
@@ -1,8 +1,11 @@
 using DrWatson
 @quickactivate "Analysis pipeline"
 
+# Include the AnalysisPipeline module
 include(srcdir("AnalysisPipeline.jl"))
+# Include the common parameter values
 include(scriptsdir("common_param_values.jl"))
+# Include the common inference scenarios
 include(scriptsdir("common_scenarios.jl"))
 
 @info("""
@@ -13,32 +16,31 @@ include(scriptsdir("common_scenarios.jl"))
 
       """)
 
-## Inference method
-# using Distributions, .AnalysisPipeline, EpiAware
+## Inference methods
+using Distributions, .AnalysisPipeline, EpiAware, JLD2, ADTypes, AbstractMCMC
 
+for filename in readdir(datadir("truth_data"))
+    # Load the truth data
+    D = JLD2.load(joinpath(datadir("truth_data"), filename))
 
-num_threads = min(10, Threads.nthreads())
-inference_method = EpiMethod(
-    pre_sampler_steps = [ManyPathfinder(nruns = 4, maxiters = 100)],
-    sampler = NUTSampler(adtype = AutoForwardDiff(),
-        ndraws = 2000,
-        nchains = num_threads,
-        mcmc_parallel = MCMCThreads())
-)
+    # Extract the gi_mean value from the filename
+    _, truth_data_vals = parse_savename(filename)
+    truth_data_gi_mean = truth_data_vals["gi_mean"]
 
-##
-config = sim_configs[end] |>
-    d -> InferenceConfig(d[:igp], d[:latent_model];
-        gi_mean = d[:gi_mean],
-        gi_std = d[:gi_std],
-        case_data = fill(100, 100),
-        tspan = (1, 25),
-        epimethod = inference_method
-    )
+    # Set up and run the inference scenarios
+    for d in sim_configs
+        config = InferenceConfig(d[:igp], d[:latent_model];
+            gi_mean = d[:gi_mean],
+            gi_std = d[:gi_std],
+            case_data = D["y_t"],
+            tspan = inference_tspan,
+            epimethod = inference_method
+        )
+        prfx = "observables" * "_igp_" * string(d[:igp]) * "_latentmodel_" *
+               naming_scheme[d[:latent_model]] * "_truth_gi_mean_" *
+               string(truth_data_gi_mean)
 
-##
-
-inference_results
-
-savename(config)
-config.igp |> string
+        data, file = produce_or_load(
+            simulate_or_infer, config, datadir("epiaware_observables"); prefix = prfx)
+    end
+end

--- a/pipeline/scripts/inference_pipeline.jl
+++ b/pipeline/scripts/inference_pipeline.jl
@@ -3,8 +3,7 @@ using DrWatson
 
 # Include the AnalysisPipeline module
 include(srcdir("AnalysisPipeline.jl"))
-# Include the common parameter values
-include(scriptsdir("common_param_values.jl"))
+
 # Include the common inference scenarios
 include(scriptsdir("common_scenarios.jl"))
 
@@ -17,7 +16,7 @@ include(scriptsdir("common_scenarios.jl"))
       """)
 
 ## Inference methods
-using Distributions, .AnalysisPipeline, EpiAware, JLD2, ADTypes, AbstractMCMC
+using JLD2
 
 for filename in readdir(datadir("truth_data"))
     # Load the truth data

--- a/pipeline/src/AnalysisPipeline.jl
+++ b/pipeline/src/AnalysisPipeline.jl
@@ -6,10 +6,11 @@ module AnalysisPipeline
 using CSV, Dagger, DataFramesMeta, Dates, Distributions, DocStringExtensions, DrWatson,
       EpiAware, Plots, Statistics
 
-export TruthSimulationConfig
+export TruthSimulationConfig, InferenceConfig
 export simulate_or_infer, savename
 
 include("docstrings.jl")
 include("TruthSimulationConfig.jl")
+include("InferenceConfig.jl")
 
 end

--- a/pipeline/src/InferenceConfig.jl
+++ b/pipeline/src/InferenceConfig.jl
@@ -93,5 +93,5 @@ function simulate_or_infer(config::InferenceConfig)
         config.epimethod,
         (y_t = config.case_data[idxs],)
     )
-    return inference_results
+    return Dict("inference_results" => inference_results)
 end

--- a/pipeline/src/InferenceConfig.jl
+++ b/pipeline/src/InferenceConfig.jl
@@ -1,6 +1,15 @@
-@kwdef struct InferenceConfig{
-    T <: Real, F <: Function, I, L, E <: AbstractEpiMethod} where {I, L},
-L
+"""
+The `InferenceConfig` struct represents the configuration parameters for the
+    inference process from case data.
+
+## Constructors
+- `InferenceConfig(igp, latent_model; gi_mean, gi_std, case_data, tspan,
+    epimethod, delay_distribution = Gamma(4, 5 / 4), log_I0_prior = Normal(log(100.0), 1e-5),
+    cluster_factor_prior = HalfNormal(0.1), transformation = exp)`: Create a new
+        `InferenceConfig` object with the specified parameters.
+
+"""
+struct InferenceConfig{T, F, I, L, E}
     "Assumed generation interval distribution mean."
     gi_mean::T
     "Assumed generation interval distribution std."
@@ -18,17 +27,17 @@ L
     "Maximum next generation interval when discretized."
     D_gen::T
     "Transformation function"
-    transformation::F = exp
+    transformation::F
     "Delay distribution: Default is Gamma(4, 5/4)."
-    delay_distribution::Distribution = Gamma(4, 5 / 4)
+    delay_distribution::Distribution
     "Maximum delay when discretized. Default is 15 days."
     D_obs::T
     "Prior for log initial infections. Default is Normal(4.6, 1e-5)."
-    log_I0_prior::Distribution = Normal(log(100.0), 1e-5)
+    log_I0_prior::Distribution
     "Prior for negative binomial cluster factor. Default is HalfNormal(0.1)."
-    cluster_factor_prior::Distribution = HalfNormal(0.1)
+    cluster_factor_prior::Distribution
 
-    function InferenceConfig(; gi_mean, gi_std, igp, latent_model, case_data, tspan,
+    function InferenceConfig(igp, latent_model; gi_mean, gi_std, case_data, tspan,
             epimethod, delay_distribution = Gamma(4, 5 / 4),
             log_I0_prior = Normal(log(100.0), 1e-5),
             cluster_factor_prior = HalfNormal(0.1),
@@ -36,13 +45,25 @@ L
         D_gen = gi_mean + 4 * gi_std
         D_obs = mean(delay_distribution) + 4 * std(delay_distribution)
 
-        new{eltype(gi_mean), typeof(transformation),
-            typeof(igp), typeof(latent_model), typeof{E}}(
+        new{typeof(gi_mean), typeof(transformation),
+        typeof(igp), typeof(latent_model), typeof(epimethod)}(
             gi_mean, gi_std, igp, latent_model, case_data, tspan, epimethod,
             D_gen, transformation, delay_distribution, D_obs, log_I0_prior, cluster_factor_prior)
     end
 end
 
+"""
+This method makes inference on the underlying parameters of the model specified
+in the `InferenceConfig` object `config`.
+
+# Arguments
+- `config::InferenceConfig`: The configuration object containing the case data
+to make inference on and model configuration.
+
+# Returns
+- `inference_results`: The results of the simulation or inference.
+
+"""
 function simulate_or_infer(config::InferenceConfig)
     #Define infection-generating model
     shape = (config.gi_mean / config.gi_std)^2
@@ -69,7 +90,7 @@ function simulate_or_infer(config::InferenceConfig)
     idxs = config.tspan[1]:config.tspan[2]
     #Return the sampled infections and observations
     inference_results = apply_method(epi_prob,
-        config.inference_method,
+        config.epimethod,
         (y_t = config.case_data[idxs],)
     )
     return inference_results

--- a/pipeline/src/InferenceConfig.jl
+++ b/pipeline/src/InferenceConfig.jl
@@ -1,0 +1,60 @@
+@kwdef struct InferenceConfig{T <: Real, F <: Function}
+    "Assumed generation interval distribution mean."
+    gi_mean::T
+    "Assumed generation interval distribution std."
+    gi_std::T
+    "Infection-generating model type."
+    igp::UnionAll
+    "Latent model type."
+    latent_model::UnionAll
+    "Case data"
+    case_data::Vector{Integer}
+    "Time to fit on"
+    tspan::Tuple{Integer, Integer}
+    "Inference method."
+    epimethod::AbstractEpiMethod
+    "Maximum next generation interval when discretized."
+    D_gen::T = T(60.0)
+    "Transformation function"
+    transformation::F = exp
+    "Delay distribution: Default is Gamma(4, 5/4)."
+    delay_distribution::Distribution = Gamma(4, 5 / 4)
+    "Maximum delay when discretized. Default is 15 days."
+    D_obs::T = T(15.0)
+    "Prior for log initial infections. Default is Normal(4.6, 1e-5)."
+    log_I0_prior::Distribution = Normal(log(100.0), 1e-5)
+    "Prior for negative binomial cluster factor. Default is HalfNormal(0.1)."
+    cluster_factor_prior::Distribution = HalfNormal(0.1)
+end
+
+function simulate_or_infer(config::InferenceConfig)
+    #Define infection-generating model
+    shape = (config.gi_mean / config.gi_std)^2
+    scale = config.gi_std^2 / config.gi_mean
+    gen_distribution = Gamma(shape, scale)
+
+    #Define the infection-generating process
+    model_data = EpiData(gen_distribution = gen_distribution, D_gen = config.D_gen,
+        transformation = config.transformation)
+
+    epi = config.igp(model_data, config.log_I0_prior)
+
+    #Define the infection conditional observation distribution
+    obs = LatentDelay(
+        NegativeBinomialError(cluster_factor_prior = config.cluster_factor_prior),
+        config.delay_distribution; D = config.D_obs)
+
+    #Define the EpiProblem
+    epi_prob = EpiProblem(epi_model = epi,
+        latent_model = config.latent_model,
+        observation_model = obs,
+        tspan = config.tspan)
+
+    idxs = config.tspan[1]:config.tspan[2]
+    #Return the sampled infections and observations
+    inference_results = apply_method(epi_prob,
+        config.inference_method,
+        (y_t = config.case_data[idxs],)
+    )
+    return inference_results
+end

--- a/pipeline/src/InferenceConfig.jl
+++ b/pipeline/src/InferenceConfig.jl
@@ -46,7 +46,7 @@ struct InferenceConfig{T, F, I, L, E}
         D_obs = mean(delay_distribution) + 4 * std(delay_distribution)
 
         new{typeof(gi_mean), typeof(transformation),
-        typeof(igp), typeof(latent_model), typeof(epimethod)}(
+            typeof(igp), typeof(latent_model), typeof(epimethod)}(
             gi_mean, gi_std, igp, latent_model, case_data, tspan, epimethod,
             D_gen, transformation, delay_distribution, D_obs, log_I0_prior, cluster_factor_prior)
     end

--- a/pipeline/test/runtests.jl
+++ b/pipeline/test/runtests.jl
@@ -7,3 +7,4 @@ include(srcdir("AnalysisPipeline.jl"))
 #run tests
 include("test_SimulationConfig.jl");
 include("test_TruthSimulationConfig.jl");
+include("test_InferenceConfig.jl");

--- a/pipeline/test/test_InferenceConfig.jl
+++ b/pipeline/test/test_InferenceConfig.jl
@@ -37,11 +37,24 @@
 end
 
 @testset "simulate_or_infer: Inference runs" begin
+    using Distributions, .AnalysisPipeline, EpiAware, ADTypes, AbstractMCMC
+
     @info "Running inference test on fake data."
 
     include(srcdir("AnalysisPipeline.jl"))
     include(scriptsdir("common_param_values.jl"))
     include(scriptsdir("common_scenarios.jl"))
+
+    # Inference method
+    num_threads = min(10, Threads.nthreads())
+
+    inference_method = EpiMethod(
+        pre_sampler_steps = [ManyPathfinder(nruns = 4, maxiters = 100)],
+        sampler = NUTSampler(adtype = AutoForwardDiff(),
+            ndraws = 2000,
+            nchains = num_threads,
+            mcmc_parallel = MCMCThreads())
+    )
 
     # Create the InferenceConfig object on a randomly selected simulation configuration
     # With fake constant case data

--- a/pipeline/test/test_InferenceConfig.jl
+++ b/pipeline/test/test_InferenceConfig.jl
@@ -61,13 +61,13 @@ end
     idx = rand(1:length(sim_configs))
 
     config = sim_configs[idx] |>
-        d -> InferenceConfig(d[:igp], d[:latent_model];
-            gi_mean = d[:gi_mean],
-            gi_std = d[:gi_std],
-            case_data = fill(100, 100), # Fake constant case data
-            tspan = (1,25),
-            epimethod = inference_method
-        )
+             d -> InferenceConfig(d[:igp], d[:latent_model];
+        gi_mean = d[:gi_mean],
+        gi_std = d[:gi_std],
+        case_data = fill(100, 100), # Fake constant case data
+        tspan = (1, 25),
+        epimethod = inference_method
+    )
 
     # Call the simulate_or_infer function
     inference_results = simulate_or_infer(config)

--- a/pipeline/test/test_InferenceConfig.jl
+++ b/pipeline/test/test_InferenceConfig.jl
@@ -1,0 +1,64 @@
+
+# Test the InferenceConfig struct constructor
+@testset "InferenceConfig" begin
+    using Distributions, .AnalysisPipeline, EpiAware
+
+    struct TestLatentModel <: AbstractLatentModel
+    end
+
+    struct TestMethod <: AbstractEpiMethod
+    end
+
+    gi_mean = 3.0
+    gi_std = 2.0
+    igp = Renewal
+    latent_model = TestLatentModel()
+    epimethod = TestMethod()
+    case_data = [10, 20, 30, 40, 50]
+    tspan = (1, 5)
+
+    config = InferenceConfig(igp, latent_model;
+        gi_mean = gi_mean,
+        gi_std = gi_std,
+        case_data = case_data,
+        tspan = tspan,
+        epimethod = epimethod
+    )
+
+    @testset "config_parameters" begin
+        @test config.gi_mean == gi_mean
+        @test config.gi_std == gi_std
+        @test config.igp == igp
+        @test config.latent_model == latent_model
+        @test config.case_data == case_data
+        @test config.tspan == tspan
+        @test config.epimethod == epimethod
+    end
+end
+
+@testset "simulate_or_infer: Inference runs" begin
+    @info "Running inference test on fake data."
+
+    include(srcdir("AnalysisPipeline.jl"))
+    include(scriptsdir("common_param_values.jl"))
+    include(scriptsdir("common_scenarios.jl"))
+
+    # Create the InferenceConfig object on a randomly selected simulation configuration
+    # With fake constant case data
+    idx = rand(1:length(sim_configs))
+
+    config = sim_configs[idx] |>
+        d -> InferenceConfig(d[:igp], d[:latent_model];
+            gi_mean = d[:gi_mean],
+            gi_std = d[:gi_std],
+            case_data = fill(100, 100), # Fake constant case data
+            tspan = (1,25),
+            epimethod = inference_method
+        )
+
+    # Call the simulate_or_infer function
+    inference_results = simulate_or_infer(config)
+
+    # Check if the results match the expected results
+    @test inference_results isa EpiAwareObservables
+end


### PR DESCRIPTION
This PR does a few things around running the inference scenario loop over possible configurations. 

Specifically, we have generated "truth data" with three different mean generation intervals (see #202 ). The proposal is that for each of these data set we run all the inference scenarios defined in the [`common_scenarios.jl`](https://github.com/CDCgov/Rt-without-renewal/blob/211-construct-and-test-a-function-for-going-from-scenario-specification-to-running-inference-at-this-point-defining-the-output-to-save-is-important/pipeline/scripts/common_scenarios.jl) script.

Contributions:
- A new type `InferenceConfig` which dispatched a method of `simulate_or_infer` that handles the `EpiAware` inference.
- A `DrWatson` style script to run the inference after defining various common values.
- A constructor unit test for `InferenceConfig` and a full inference run test on a short bit of fake data using a randomly selected inference scenario.