### PR TITLE
Implementing `Dagger.@spawn` for pipeline jobs

### DIFF
--- a/pipeline/scripts/analysis_pipeline.jl
+++ b/pipeline/scripts/analysis_pipeline.jl
@@ -3,10 +3,8 @@ using DrWatson
 
 # Activate the project environment
 # Analogy: source(functions.R) in targets
-@quickactivate "Analysis pipeline"
-
-# Include the AnalysisPipeline module
-include(srcdir("AnalysisPipeline.jl"));
+quickactivate(@__DIR__(), "Analysis pipeline")
+using Dagger
 
 @info("""
       Running the analysis pipeline.
@@ -17,7 +15,18 @@ include(srcdir("AnalysisPipeline.jl"));
 
 ## Other dependencies
 # Analogy: tar_option_set(...) in targets
-using .AnalysisPipeline
+# Add processes for parallel computing and ensure all have same
+# dependencies/environment
+using Distributed
+addprocs(1)
+
+@everywhere begin
+    using DrWatson
+    quickactivate(@__DIR__(), "Analysis pipeline")
+    include(srcdir("AnalysisPipeline.jl"))
+end
+
+@everywhere using .AnalysisPipeline
 
 ## Run the pipeline steps
 # Analogy: list(tar_targets...) followed by tar_make(...) in targets
@@ -25,42 +34,51 @@ using .AnalysisPipeline
 # scheduler for these tasks in the next commit. Probably Dagger.jl
 
 # Default parameter values and plot true Rt
-default_gi_param_dict = default_gi_params()
-true_Rt = default_Rt()
-plt_Rt = plot_Rt(true_Rt)
-latent_models_dict = default_epiaware_models()
-latent_models_names = Dict(value => key for (key, value) in latent_models_dict)
-tspan = default_tspan()
-inference_method = default_inference_method()
+# @everywhere begin
+#     default_gi_param_dict = default_gi_params()
+#     true_Rt = default_Rt()
+#     plt_Rt = plot_Rt(true_Rt)
+#     latent_models_dict = default_epiaware_models()
+#     latent_models_names = Dict(value => key for (key, value) in latent_models_dict)
+#     tspan = default_tspan()
+#     inference_method = default_inference_method()
+# end
+
+default_gi_param_dict_thunk = Dagger.@spawn default_gi_params()
+true_Rt_thunk = Dagger.@spawn default_Rt()
+plt_Rt_thunk = Dagger.@spawn plot_Rt(true_Rt_thunk)
+latent_models_dict_thunk = Dagger.@spawn default_epiaware_models()
+latent_models_names_thunk = Dagger.@spawn default_latent_models_names()
+tspan_thunk = Dagger.@spawn default_tspan()
+inference_method_thunk = Dagger.@spawn default_inference_method()
+
+# fetch the default GI parameters and latent models from their `EagerThunk`s
+default_gi_param_dict = fetch(default_gi_param_dict_thunk)
+latent_models_dict = fetch(latent_models_dict_thunk)
 
 # truth data configurations (e.g. different GI means)
+
 truth_data_configs = make_truth_data_configs(
     gi_means = default_gi_param_dict["gi_means"], gi_stds = default_gi_param_dict["gi_stds"])
 
 # inference configurations
 # (e.g. different infection generation processes and latent models etc.)
-
 inference_configs = make_inference_configs(
     latent_models = collect(values(latent_models_dict)),
     gi_means = default_gi_param_dict["gi_means"],
     gi_stds = default_gi_param_dict["gi_stds"])
 
 # Produce and save the truth data
-truth_data_scenarios = map(truth_data_configs) do truth_data_config
-    @info "Running truth data scenario with GI mean: $(truth_data_config["gi_mean"])"
+truthdata_from_configs = @sync map(truth_data_configs) do truth_data_config
     # generate truth data
-    truthdata, truthfile = generate_truthdata_from_config(
+    truth_thunk = Dagger.@spawn generate_truthdata_from_config(
         truth_data_config; plot = true)
-
-    # Run the inference scenarios
-    map(inference_configs) do inference_config
-        @info "Running inference scenario with IGP: $(inference_config["igp"]), latent model: " *
-              latent_models_names[inference_config["latent_model"]]
-        inference_results, inferencefile = generate_inference_results(
-            truthdata, inference_config; tspan, inference_method,
-            truth_data_config, latent_models_names)
-        return nothing
+    # # Run the inference scenarios
+    for inference_config in inference_configs
+        inference_thunks = Dagger.@spawn generate_inference_results(
+            truth_thunk, inference_config; tspan_thunk, inference_method_thunk,
+            truth_data_config, latent_models_names_thunk)
     end
-
+    truthdata = fetch(truth_thunk)
     return truthdata
 end

--- a/pipeline/src/AnalysisPipeline.jl
+++ b/pipeline/src/AnalysisPipeline.jl
@@ -12,10 +12,9 @@ export TruthSimulationConfig, InferenceConfig
 
 # Exported functions
 export simulate_or_infer, default_gi_params, default_Rt, default_tspan,
-       default_latent_model_priors,
-       default_epiaware_models, default_inference_method, make_truth_data_configs,
-       make_inference_configs, generate_truthdata_from_config, generate_inference_results,
-       plot_truth_data, plot_Rt
+       default_latent_model_priors, default_epiaware_models, default_inference_method,
+       default_latent_models_names, make_truth_data_configs, make_inference_configs,
+       generate_truthdata_from_config, generate_inference_results, plot_truth_data, plot_Rt
 
 include("docstrings.jl")
 include("default_gi_params.jl")
@@ -26,6 +25,7 @@ include("default_epiaware_models.jl")
 include("default_inference_method.jl")
 include("make_truth_data_configs.jl")
 include("make_inference_configs.jl")
+include("default_latent_models_names.jl")
 include("TruthSimulationConfig.jl")
 include("InferenceConfig.jl")
 include("generate_truthdata.jl")

--- a/pipeline/src/default_inference_method.jl
+++ b/pipeline/src/default_inference_method.jl
@@ -1,33 +1,29 @@
 """
-Constructs a default inference method.
+Constructs and returns an `EpiMethod` object with default settings for inference.
 
 # Arguments
-- `max_threads::Integer`: The maximum number of threads to use for multi-threaded
-    parallel computation, this also sets the number of chains. Default is
-    maximum is 10.
-- `ndraws::Integer`: The number of draws to generate from the posterior
-    distribution. Default is 2000.
+- `max_threads::Integer`: The maximum number of threads to use for parallelization.
+    Default is 10.
+- `ndraws::Integer`: The number of MCMC samples to draw. Default is 2000.
 - `mcmc_ensemble::AbstractMCMC.AbstractMCMCEnsemble`: The MCMC ensemble to use
-    for parallel sampling. Default is MCMCThreads().
-- `nruns_pthf::Integer`: The number of runs for the pre-sampler ManyPathfinder.
+    for parallelization. Default is `MCMCSerial()`; that is no parallelization.
+- `nruns_pthf::Integer`: The number of runs for the pre-sampler steps.
     Default is 4.
 - `maxiters_pthf::Integer`: The maximum number of iterations for the pre-sampler
-    ManyPathfinder. Default is 100.
+    steps. Default is 100.
+- `nchains::Integer`: The number of MCMC chains to run. Default is 2.
 
 # Returns
-- An `EpiMethod` object representing the default inference method.
-
+An `EpiMethod` object with the specified settings.
 """
 function default_inference_method(; max_threads::Integer = 10, ndraws::Integer = 2000,
-        mcmc_ensemble::AbstractMCMC.AbstractMCMCEnsemble = MCMCThreads(),
-        nruns_pthf::Integer = 4, maxiters_pthf::Integer = 100)
-    num_threads = min(max_threads, Threads.nthreads())
-
+        mcmc_ensemble::AbstractMCMC.AbstractMCMCEnsemble = MCMCSerial(),
+        nruns_pthf::Integer = 4, maxiters_pthf::Integer = 100, nchains::Integer = 2)
     return EpiMethod(
         pre_sampler_steps = [ManyPathfinder(nruns = nruns_pthf, maxiters = maxiters_pthf)],
         sampler = NUTSampler(adtype = AutoForwardDiff(),
             ndraws = ndraws,
-            nchains = num_threads,
+            nchains = nchains,
             mcmc_parallel = mcmc_ensemble)
     )
 end

--- a/pipeline/src/default_latent_models_names.jl
+++ b/pipeline/src/default_latent_models_names.jl
@@ -1,0 +1,12 @@
+"""
+Returns a dictionary mapping the default latent models to their corresponding
+    names.
+
+# Returns
+- `Dict{Any, Any}`: A dictionary mapping the default latent models to their
+    corresponding names.
+"""
+function default_latent_models_names()
+    latent_models_dict = default_epiaware_models()
+    return Dict(value => key for (key, value) in latent_models_dict)
+end

--- a/pipeline/src/generate_truthdata.jl
+++ b/pipeline/src/generate_truthdata.jl
@@ -22,5 +22,5 @@ function generate_truthdata_from_config(
     if plot
         plot_truth_data(truthdata, config)
     end
-    return truthdata, truthfile
+    return truthdata
 end

--- a/pipeline/test/default_returning_functions.jl
+++ b/pipeline/test/default_returning_functions.jl
@@ -57,6 +57,14 @@ end
     @test method.sampler isa NUTSampler
     @test method.sampler.adtype == AutoForwardDiff()
     @test method.sampler.ndraws == 2000
-    @test method.sampler.nchains == min(10, Threads.nthreads())
-    @test method.sampler.mcmc_parallel == MCMCThreads()
+    @test method.sampler.nchains == 2
+    @test method.sampler.mcmc_parallel == MCMCSerial()
+end
+
+@testset "Test default_latent_models_names" begin
+    using .AnalysisPipeline
+
+    modelnames = default_latent_models_names()
+    @test length(modelnames) == 3
+    @test modelnames isa Dict
 end

--- a/pipeline/test/runtests.jl
+++ b/pipeline/test/runtests.jl
@@ -1,12 +1,12 @@
 using DrWatson, Test
-@quickactivate "Analysis pipeline"
+quickactivate(@__DIR__(), "Analysis pipeline")
 
 # Load analysis module
-include(srcdir("AnalysisPipeline.jl"))
+include(srcdir("AnalysisPipeline.jl"));
 
 #run tests
 include("default_returning_functions.jl");
-include("test_make_configs.jl")
+include("test_make_configs.jl");
 include("test_SimulationConfig.jl");
 include("test_TruthSimulationConfig.jl");
 include("test_InferenceConfig.jl");

--- a/pipeline/test/test_TruthSimulationConfig.jl
+++ b/pipeline/test/test_TruthSimulationConfig.jl
@@ -20,7 +20,7 @@ end
 
 @testset "generate_truthdata_from_config" begin
     truth_data_config = Dict("gi_mean" => 0.5, "gi_std" => 0.1)
-    truthdata, truthfile = generate_truthdata_from_config(truth_data_config)
+    truthdata = generate_truthdata_from_config(truth_data_config)
 
     @test haskey(truthdata, "I_t")
     @test haskey(truthdata, "y_t")
@@ -28,5 +28,4 @@ end
     @test haskey(truthdata, "truth_process")
     @test haskey(truthdata, "truth_gi_mean")
     @test haskey(truthdata, "truth_gi_std")
-    @test typeof(truthfile) == String
 end


### PR DESCRIPTION
This PR rewrites the main pipeline script to use [`Dagger.jl`](https://github.com/JuliaParallel/Dagger.jl) to execute the analysis as a [DAG of spawned tasks](https://en.wikipedia.org/wiki/Directed_acyclic_graph#Scheduling).

Notable changes/decisions:
- The string names of each model now have a default constructor function.
- Nearly all function calls are first created as a task using `Dagger.@spawn`, with results fetched as required or passing `EagerThunk` objects to downstream tasks to get executed in a schedule determined by `Dagger`. Not all of this is necessary (could be replaced by e.g. `@everywhere ...some code...`), but maintains the pattern and should be more extensible.
- Construction of the list of scenarios is not a `Dagger` generated task; I'm viewing this a being created by an orchestrating main node which then implicitly defines the DAG topology. Happy to get pushed back on this.
- The default inference is now serial with 2 sequentially executed MCMC chains. I'm assuming that we'll aim for deploying resources to parallelise across tasks rather than within tasks.
- **Checkpointing.** I've checked that doing the inference as a set of tasks is compatible with the checkpointing provided by `DrWatson.produce_or_load`. `Dagger` can provide more methods of checkpointing, but at the moment saving to disk and recognising that a task has been completed by the existence of a saved file works. However, we should have a think about vulnerability to an edge case causing an error?

Closes #219 .