### PR TITLE
prior predictive modelling for each inference model

### DIFF
--- a/pipeline/data/epiaware_observables/placeholder.md
+++ b/pipeline/data/epiaware_observables/placeholder.md
@@ -1,0 +1,1 @@
+# placeholder

--- a/pipeline/scripts/run_priorpred_pipeline.jl
+++ b/pipeline/scripts/run_priorpred_pipeline.jl
@@ -1,0 +1,26 @@
+# Local environment script to run the analysis pipeline
+using Pkg
+Pkg.activate(joinpath(@__DIR__(), ".."))
+using Dagger
+
+@info("""
+      Running the analysis pipeline.
+      --------------------------------------------
+      """)
+
+# Define the backend resources to use for the pipeline
+# in this case we are using distributed local workers with loaded modules
+using Distributed
+pids = addprocs()
+
+@everywhere include("../src/AnalysisPipeline.jl")
+@everywhere using .AnalysisPipeline
+
+# Create an instance of the pipeline behaviour
+pipeline = RtwithoutRenewalPriorPipeline()
+
+# Run the pipeline
+do_pipeline(pipeline)
+
+# Remove the workers
+rmprocs(pids)

--- a/pipeline/src/AnalysisPipeline.jl
+++ b/pipeline/src/AnalysisPipeline.jl
@@ -13,9 +13,12 @@ module AnalysisPipeline
 using CSV, Dagger, DataFramesMeta, Dates, Distributions, DocStringExtensions, DrWatson,
       EpiAware, Plots, Statistics, ADTypes, AbstractMCMC, Plots, JLD2
 
-# Exported struct types
+# Exported pipeline types
 export AbstractEpiAwarePipeline, EpiAwarePipeline, RtwithoutRenewalPipeline,
-       TruthSimulationConfig, InferenceConfig
+       RtwithoutRenewalPriorPipeline
+
+# Exported configuration types
+export TruthSimulationConfig, InferenceConfig
 
 # Exported functions: constructors
 export make_gi_params, make_inf_generating_processes, make_latent_model_priors,

--- a/pipeline/src/constructors/make_inference_method.jl
+++ b/pipeline/src/constructors/make_inference_method.jl
@@ -17,3 +17,13 @@ function make_inference_method(pipeline::AbstractEpiAwarePipeline; ndraws::Integ
             nchains = nchains, mcmc_parallel = mcmc_ensemble)
     )
 end
+
+"""
+Method for sampling from prior predictive distribution of the model.
+"""
+function make_inference_method(pipeline::RtwithoutRenewalPriorPipeline; n_samples = 2_000)
+    return EpiMethod(
+        pre_sampler_steps = AbstractEpiOptMethod[],
+        sampler = DirectSample(n_samples = n_samples)
+    )
+end

--- a/pipeline/src/infer/InferenceConfig.jl
+++ b/pipeline/src/infer/InferenceConfig.jl
@@ -19,7 +19,7 @@ struct InferenceConfig{T, F, I, L, E}
     "Latent model type."
     latent_model::L
     "Case data"
-    case_data::Vector{Integer}
+    case_data::Union{Vector{Integer}, Missing}
     "Time to fit on"
     tspan::Tuple{Integer, Integer}
     "Inference method."
@@ -89,9 +89,10 @@ function infer(config::InferenceConfig)
 
     idxs = config.tspan[1]:config.tspan[2]
     #Return the sampled infections and observations
+    y_t = ismissing(config.case_data) ? missing : config.case_data[idxs]
     inference_results = apply_method(epi_prob,
         config.epimethod,
-        (y_t = config.case_data[idxs],)
+        (y_t = y_t,)
     )
     return Dict("inference_results" => inference_results)
 end

--- a/pipeline/src/infer/generate_inference_results.jl
+++ b/pipeline/src/infer/generate_inference_results.jl
@@ -35,3 +35,29 @@ function generate_inference_results(
         infer, config, datadir(datadir_name); prefix = prfx)
     return inference_results
 end
+
+"""
+Method for prior predictive modelling.
+"""
+function generate_inference_results(
+        truthdata, inference_config, pipeline::RtwithoutRenewalPriorPipeline;
+        tspan, inference_method,
+        prfix_name = "prior_observables", datadir_name = "epiaware_observables")
+    config = InferenceConfig(
+        inference_config["igp"], inference_config["latent_namemodels"].second;
+        gi_mean = inference_config["gi_mean"],
+        gi_std = inference_config["gi_std"],
+        case_data = missing,
+        tspan = tspan,
+        epimethod = inference_method
+    )
+
+    # produce or load inference results
+    prfx = prfix_name * "_igp_" * string(inference_config["igp"]) * "_latentmodel_" *
+           inference_config["latent_namemodels"].first * "_truth_gi_mean_" *
+           string(truthdata["truth_gi_mean"])
+
+    inference_results, inferencefile = produce_or_load(
+        infer, config, datadir(datadir_name); prefix = prfx)
+    return inference_results
+end

--- a/pipeline/src/infer/map_inference_results.jl
+++ b/pipeline/src/infer/map_inference_results.jl
@@ -15,7 +15,7 @@ tasks from `Dagger.@spawn`.
 
 """
 function map_inference_results(
-        truthdata, inference_configs, pipeline; tspan, inference_method)
+        truthdata, inference_configs, pipeline::AbstractEpiAwarePipeline; tspan, inference_method)
     map(inference_configs) do inference_config
         Dagger.@spawn generate_inference_results(
             truthdata, inference_config, pipeline; tspan, inference_method)

--- a/pipeline/src/pipeline/pipelinetypes.jl
+++ b/pipeline/src/pipeline/pipelinetypes.jl
@@ -9,3 +9,10 @@ The pipeline type for the Rt pipeline with renewal including specific options
 """
 struct RtwithoutRenewalPipeline <: AbstractEpiAwarePipeline
 end
+
+"""
+The pipeline type for the Rt pipeline without renewal with only prior predictive
+    modelling.
+"""
+struct RtwithoutRenewalPriorPipeline <: AbstractEpiAwarePipeline
+end

--- a/pipeline/test/constructors/test_constructors.jl
+++ b/pipeline/test/constructors/test_constructors.jl
@@ -73,6 +73,16 @@ end
     @test method.sampler.mcmc_parallel == MCMCSerial()
 end
 
+@testset "make_inference_method: for prior predictive checking" begin
+    using .AnalysisPipeline, EpiAware, ADTypes, AbstractMCMC
+    pipeline = RtwithoutRenewalPriorPipeline()
+
+    method = make_inference_method(pipeline)
+
+    @test length(method.pre_sampler_steps) == 0
+    @test method.sampler isa DirectSample
+end
+
 @testset "make_truth_data_configs" begin
     using .AnalysisPipeline
     pipeline = RtwithoutRenewalPipeline()

--- a/pipeline/test/test_prior_predictive.jl
+++ b/pipeline/test/test_prior_predictive.jl
@@ -1,0 +1,20 @@
+using Test
+@testset "run prior predictive modelling for random scenario" begin
+    using DrWatson, EpiAware
+    quickactivate(@__DIR__(), "Analysis pipeline")
+    include(srcdir("AnalysisPipeline.jl"))
+
+    using .AnalysisPipeline
+    pipeline = RtwithoutRenewalPriorPipeline()
+
+    tspan = (1, 28)
+    inference_method = make_inference_method(pipeline)
+    truth_data_config = make_truth_data_configs(pipeline)[1]
+    inference_configs = make_inference_configs(pipeline)
+    inference_config = rand(inference_configs)
+    truthdata = Dict("y_t" => fill(100, 28), "truth_gi_mean" => 1.5)
+
+    inference_results = generate_inference_results(
+        truthdata, inference_config, pipeline; tspan, inference_method)
+    @test inference_results["inference_results"] isa EpiAwareObservables
+end


### PR DESCRIPTION
This PR adds a pipeline for generating prior predictive samples from the list of inference model types as discussed in #227 . The approach is to define a new `<: AbstractEpiAwarePipeline` type `RtwithoutRenewalPriorPipeline` which dispatches a method for:
1. Only passing `missing` data to the inference problem.
2. Uses `DirectSample` to sample from the model.

Also adds some tests for this and a pipeline script.

Closes #227 .