### PR TITLE
Issue 176: Add support for multiple observation models

### DIFF
--- a/EpiAware/src/EpiObsModels/EpiObsModels.jl
+++ b/EpiAware/src/EpiObsModels/EpiObsModels.jl
@@ -9,11 +9,16 @@ using ..EpiAwareUtils: censored_pmf, HalfNormal
 
 using Turing, Distributions, DocStringExtensions, SparseArrays
 
-export PoissonError, NegativeBinomialError, LatentDelay, Ascertainment
+# Observation models
+export PoissonError, NegativeBinomialError
+
+# Observation model modifiers
+export LatentDelay, Ascertainment, StackObservationModels
 
 include("docstrings.jl")
 include("LatentDelay.jl")
 include("Ascertainment.jl")
+include("StackObservationModels.jl")
 include("PoissonError.jl")
 include("NegativeBinomialError.jl")
 include("utils.jl")

--- a/EpiAware/src/EpiObsModels/StackObservationModels.jl
+++ b/EpiAware/src/EpiObsModels/StackObservationModels.jl
@@ -28,15 +28,6 @@ obs_model = generate_observations(obs, y_t, fill(10, 10))
 rand(obs_model)
 samples = sample(obs_model, Prior(), 100; progress = false)
 
-# extract samples for cases.y_t and deaths_y_t
-# from the chain of samples (not using generated_quantities)
-function extract_obs(samples, obs_name)
-    obs = group(samples, obs_name) |>
-          DataFrame |>
-          x -> stack(x, Not(:iteration, :chain))
-    return obs
-end
-
 cases_y_t = group(samples, \"cases.y_t\")
 cases_y_t
 

--- a/EpiAware/src/EpiObsModels/StackObservationModels.jl
+++ b/EpiAware/src/EpiObsModels/StackObservationModels.jl
@@ -1,0 +1,30 @@
+@kwdef struct StackObservationModels{
+    M <: AbstractVector{<:AbstractTuringObservationModel},
+    N <: AbstractVector{<:AbstractString}} <:
+              AbstractTuringObservationModel
+    "A vector of observation models."
+    models::M
+    "A vector of observation model names"
+    model_names::N
+
+    function StackObservationModels(models::Vector{<:M},
+            model_names::Vector{<:N}) where {
+            M <: AbstractTuringObservationModel,
+            N <: AbstractString
+    }
+        @assert length(models)==length(model_names) "The number of models and model names must be equal."
+        new{typeof(models), typeof(model_names)}(models, model_names)
+    end
+
+    function StackObservationModels(models::Vector{<:M}) where {
+            M <: AbstractTuringObservationModel
+    }
+        model_names = [typeof(i) for i in 1:length(models)]
+        return StackObservationModels(models, model_names)
+    end
+
+    function StackObservationsModels(models::NamedTuple)
+        # use the keys of the NamedTuple as the model names
+        return StackObservationModels(values(models), keys(models))
+    end
+end

--- a/EpiAware/src/EpiObsModels/StackObservationModels.jl
+++ b/EpiAware/src/EpiObsModels/StackObservationModels.jl
@@ -10,8 +10,6 @@ each model in the stack. Note that the model names are used to prefix the parame
     - `StackObservationModels(; models::Vector{<:AbstractTuringObservationModel},
     model_names::Vector{<:AbstractString})`: Construct a `StackObservationModels` object with a vector of observation models and a
     vector of model names.
-- `StackObservationModels(models::Vector{<:AbstractTuringObservationModel})`:
-    Construct a `StackObservationModels` object with a vector of observation models. The model names are automatically generated from the observation model types.
 - `StackObservationModels(models::NamedTuple{names, T})`: Construct a
     `StackObservationModels` object with a named tuple of observation models. The model names are automatically generated from the keys of the named tuple.
 
@@ -51,16 +49,6 @@ deaths_y_t
     }
         @assert length(models)==length(model_names) "The number of models and model names must be equal."
         new{typeof(models), typeof(model_names)}(models, model_names)
-    end
-
-    function StackObservationModels(models::Vector{<:M}) where {
-            M <: AbstractTuringObservationModel
-    }
-        model_names = models .|>
-                      typeof .|>
-                      nameof .|>
-                      string
-        return StackObservationModels(models, model_names)
     end
 
     function StackObservationModels(models::NamedTuple{

--- a/EpiAware/src/EpiObsModels/StackObservationModels.jl
+++ b/EpiAware/src/EpiObsModels/StackObservationModels.jl
@@ -1,3 +1,49 @@
+@doc raw"
+
+A stack of observation models that are looped over to generate observations for
+each model in the stack. Note that the model names are used to prefix the parameters in each model (so if I have a model named `cases` and a parameter `y_t`, the parameter in the model will be `cases.y_t`).
+
+## Constructors
+
+- `StackObservationModels(models::Vector{<:AbstractTuringObservationModel},
+    model_names::Vector{<:AbstractString})`: Construct a `StackObservationModels` object with a vector of observation models and a vector of model names.
+    - `StackObservationModels(; models::Vector{<:AbstractTuringObservationModel},
+    model_names::Vector{<:AbstractString})`: Construct a `StackObservationModels` object with a vector of observation models and a
+    vector of model names.
+- `StackObservationModels(models::Vector{<:AbstractTuringObservationModel})`:
+    Construct a `StackObservationModels` object with a vector of observation models. The model names are automatically generated from the observation model types.
+- `StackObservationModels(models::NamedTuple{names, T})`: Construct a
+    `StackObservationModels` object with a named tuple of observation models. The model names are automatically generated from the keys of the named tuple.
+
+## Example
+
+```julia
+using EpiAware, Turing
+
+obs = StackObservationModels(
+    (cases = PoissonError(), deaths = NegativeBinomialError())
+)
+y_t = (cases = missing, deaths = missing)
+obs_model = generate_observations(obs, y_t, fill(10, 10))
+rand(obs_model)
+samples = sample(obs_model, Prior(), 100; progress = false)
+
+# extract samples for cases.y_t and deaths_y_t
+# from the chain of samples (not using generated_quantities)
+function extract_obs(samples, obs_name)
+    obs = group(samples, obs_name) |>
+          DataFrame |>
+          x -> stack(x, Not(:iteration, :chain))
+    return obs
+end
+
+cases_y_t = group(samples, \"cases.y_t\")
+cases_y_t
+
+deaths_y_t = group(samples, \"deaths.y_t\")
+deaths_y_t
+```
+"
 @kwdef struct StackObservationModels{
     M <: AbstractVector{<:AbstractTuringObservationModel},
     N <: AbstractVector{<:AbstractString}} <:
@@ -36,15 +82,40 @@
     end
 end
 
+@doc raw"
+Generate observations from a stack of observation models. Assumes a 1 to 1 mapping between `y_t` and `Y_t`.
+
+# Arguments
+- `obs_model::StackObservationModels`: The stack of observation models.
+- `y_t::NamedTuple`: The observed values.
+- `Y_t::NamedTuple`: The expected values.
+"
 @model function EpiAwareBase.generate_observations(
-        obs_model::StackObservationModels, y_t::NamedTuple, Y_t)
+        obs_model::StackObservationModels, y_t::NamedTuple, Y_t::NamedTuple)
     @assert length(obs_model.models)==length(y_t) "The number of models and observations datasets must be equal."
     @assert obs_model.model_names==keys(y_t) .|> string |> collect "The model names must match the keys of the observation datasets."
+    @assert keys(y_t)==keys(Y_t) "The keys of the observed and true values must match."
+
     obs = ()
     for (model, model_name) in zip(obs_model.models, obs_model.model_names)
         @submodel prefix=eval(model_name) obs_tmp=generate_observations(
-            model, y_t[Symbol(model_name)], Y_t)
+            model, y_t[Symbol(model_name)], Y_t[Symbol(model_name)])
         obs = obs..., obs_tmp...
     end
+    return obs
+end
+
+@doc raw"
+Generate observations from a stack of observation models. Maps `Y_t` to a `NamedTuple` of the same length as `y_t` assuming a 1 to many mapping.
+
+# Arguments
+- `obs_model::StackObservationModels`: The stack of observation models.
+- `y_t::NamedTuple`: The observed values.
+- `Y_t::AbstractVector`: The expected values.
+"
+@model function EpiAwareBase.generate_observations(
+        obs_model::StackObservationModels, y_t::NamedTuple, Y_t::AbstractVector)
+    tuple_Y_t = NamedTuple{keys(y_t)}(fill(Y_t, length(y_t)))
+    @submodel obs = generate_observations(obs_model, y_t, tuple_Y_t)
     return obs
 end

--- a/EpiAware/src/EpiObsModels/StackObservationModels.jl
+++ b/EpiAware/src/EpiObsModels/StackObservationModels.jl
@@ -37,11 +37,13 @@
 end
 
 @model function EpiAwareBase.generate_observations(
-        obs_model::StackObservationModels, y_t, Y_t)
+        obs_model::StackObservationModels, y_t::NamedTuple, Y_t)
+    @assert length(obs_model.models)==length(y_t) "The number of models and observations datasets must be equal."
+    @assert obs_model.model_names==keys(y_t) .|> string |> collect "The model names must match the keys of the observation datasets."
     obs = ()
     for (model, model_name) in zip(obs_model.models, obs_model.model_names)
         @submodel prefix=eval(model_name) obs_tmp=generate_observations(
-            model, y_t, Y_t)
+            model, y_t[Symbol(model_name)], Y_t)
         obs = obs..., obs_tmp...
     end
     return obs

--- a/EpiAware/test/EpiObsModels/StackObservationModels.jl
+++ b/EpiAware/test/EpiObsModels/StackObservationModels.jl
@@ -5,11 +5,6 @@
     @test obs.models == [PoissonError(), NegativeBinomialError()]
     @test obs.model_names == ["Poisson", "NegativeBinomial"]
 
-    obs_type = StackObservationModels([PoissonError(), NegativeBinomialError()])
-
-    @test obs_type.models == [PoissonError(), NegativeBinomialError()]
-    @test obs_type.model_names == ["PoissonError", "NegativeBinomialError"]
-
     obs_named = StackObservationModels((
         Cases = PoissonError(), Deaths = NegativeBinomialError()))
 

--- a/EpiAware/test/EpiObsModels/StackObservationModels.jl
+++ b/EpiAware/test/EpiObsModels/StackObservationModels.jl
@@ -1,0 +1,51 @@
+@testitem "StackObservationModels constructor" begin
+    obs = StackObservationModels(
+        [PoissonError(), NegativeBinomialError()], ["Poisson", "NegativeBinomial"])
+
+    @test obs.models == [PoissonError(), NegativeBinomialError()]
+    @test obs.model_names == ["Poisson", "NegativeBinomial"]
+
+    obs_type = StackObservationModels([PoissonError(), NegativeBinomialError()])
+
+    @test obs_type.models == [PoissonError(), NegativeBinomialError()]
+    @test obs_type.model_names == ["PoissonError", "NegativeBinomialError"]
+
+    obs_named = StackObservationModels((
+        Cases = PoissonError(), Deaths = NegativeBinomialError()))
+
+    @test obs_named.models == [PoissonError(), NegativeBinomialError()]
+    @test obs_named.model_names == ["Cases", "Deaths"]
+end
+
+@testitem "StackObervationModels generate_observations works as expected" begin
+    using Turing, DynamicPPL
+
+    struct TestObs <: AbstractTuringObservationModel
+        mean::Float64
+        std::Float64
+    end
+
+    @model function EpiAwareBase.generate_observations(obs_model::TestObs, y_t, Y_t)
+        if ismissing(y_t)
+            y_t = Vector{Int}(undef, length(Y_t))
+        end
+
+        for i in eachindex(y_t)
+            y_t[i] ~ Normal(obs_model.mean, obs_model.std)
+        end
+        return y_t, (; cluster_factor = obs_model.mean)
+    end
+
+    obs = StackObservationModels(
+        [TestObs(10, 2), TestObs(20, 1)], ["cases", "deaths"]
+    )
+
+    y_t = missing
+    Y_t = fill(10, 10)
+
+    gen_obs = generate_observations(obs, y_t, Y_t)
+
+    samples = sample(gen_obs, Prior(), 100; progress = false)
+    gen = mapreduce(vcat, generated_quantities(gen_obs, samples))
+    @test all(gen .== 10.0)
+end

--- a/EpiAware/test/EpiObsModels/StackObservationModels.jl
+++ b/EpiAware/test/EpiObsModels/StackObservationModels.jl
@@ -18,7 +18,7 @@
 end
 
 @testitem "StackObervationModels generate_observations works as expected" begin
-    using Turing, DynamicPPL
+    using Turing, DynamicPPL, DataFrames
 
     struct TestObs <: AbstractTuringObservationModel
         mean::Float64
@@ -40,12 +40,30 @@ end
         [TestObs(10, 2), TestObs(20, 1)], ["cases", "deaths"]
     )
 
-    y_t = missing
+    y_t = (cases = missing, deaths = missing)
     Y_t = fill(10, 10)
 
     gen_obs = generate_observations(obs, y_t, Y_t)
 
-    samples = sample(gen_obs, Prior(), 100; progress = false)
-    gen = mapreduce(vcat, generated_quantities(gen_obs, samples))
-    @test all(gen .== 10.0)
+    samples = sample(gen_obs, Prior(), 1000; progress = false)
+
+    # extract samples for cases.y_t and deaths_y_t
+    # from the chain of samples (not using generated_quantities)
+    function extract_obs(samples, obs_name)
+        obs = group(samples, obs_name) |>
+              DataFrame |>
+              x -> stack(x, Not(:iteration, :chain)) |>
+                   x -> x[!, :value]
+        return obs
+    end
+
+    cases_y_t = extract_obs(samples, "cases.y_t")
+
+    @test isapprox(mean(cases_y_t), 10.0, atol = 0.1)
+    @test isapprox(std(cases_y_t), 2.0, atol = 0.1)
+
+    deaths_y_t = extract_obs(samples, "deaths.y_t")
+
+    @test isapprox(mean(deaths_y_t), 20, atol = 0.1)
+    @test isapprox(std(deaths_y_t), 1.0, atol = 0.1)
 end

--- a/EpiAware/test/Project.toml
+++ b/EpiAware/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataFramesMeta = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"


### PR DESCRIPTION
This PR closes #176 by adding a new `StackObservationModels` which supports arbitary stacks of observation models with both 1 to 1 and 1 to many infection -> obs mappings.

Note that this does not support the passing of unnamed `y_t` in the generated quantities (in the sense of it making no effort to track these) as long term this doesn't seem sustainable - especially due to the lack of integration with `prefix`.

This implies we are expecting posterior predictions to be done on data using the `y_t` (with prefix) sampled at the lowest level of the stack.

 if we did want to keep more in the returns this we would need manually prefix I think. To me this suggests a package wide rethink of the use of `return` is needed.