### PR TITLE
Issue 183: buffering of latent delays

### DIFF
--- a/EpiAware/src/EpiObsModels/LatentDelay.jl
+++ b/EpiAware/src/EpiObsModels/LatentDelay.jl
@@ -1,6 +1,9 @@
 @doc raw"
 The `LatentDelay` struct represents an observation model that introduces a latent delay in the observations. It is a subtype of `AbstractTuringObservationModel`.
 
+Note that the `LatentDelay` observation model shortens the observation vector by the length of the delay distribution and this is then passed to the underlying observation model. This is to prevent fitting to partially
+observed data.
+
 ## Fields
 - `model::M`: The underlying observation model.
 - `pmf::T`: The probability mass function (PMF) representing the delay distribution.
@@ -52,10 +55,20 @@ Generates observations based on the `LatentDelay` observation model.
 
 "
 @model function EpiAwareBase.generate_observations(obs_model::LatentDelay, y_t, Y_t)
-    kernel = generate_observation_kernel(obs_model.pmf, length(Y_t))
-    expected_obs = kernel * Y_t
+    if ismissing(y_t)
+        y_t = Vector{Int}(undef, length(Y_t))
+    end
+    unobs_y_t = length(obs_model.pmf)
+    nobs_Y_t = length(Y_t) - unobs_y_t + 1
+    @assert unobs_y_t<=length(y_t) "The delay PMF must be shorter than or equal to the observation vector"
 
-    @submodel y_t, obs_aux = generate_observations(obs_model.model, y_t, expected_obs)
+    kernel = generate_observation_kernel(obs_model.pmf, nobs_Y_t)
+    expected_obs = kernel * Y_t[unobs_y_t:end]
+
+    @submodel y_t_aux, obs_aux = generate_observations(
+        obs_model.model, y_t[unobs_y_t:end], expected_obs)
+
+    y_t[unobs_y_t:end] = y_t_aux
 
     return y_t, (; obs_aux...)
 end

--- a/EpiAware/src/EpiObsModels/LatentDelay.jl
+++ b/EpiAware/src/EpiObsModels/LatentDelay.jl
@@ -55,20 +55,15 @@ Generates observations based on the `LatentDelay` observation model.
 
 "
 @model function EpiAwareBase.generate_observations(obs_model::LatentDelay, y_t, Y_t)
-    if ismissing(y_t)
-        y_t = Vector{Int}(undef, length(Y_t))
-    end
     unobs_y_t = length(obs_model.pmf)
     nobs_Y_t = length(Y_t) - unobs_y_t + 1
-    @assert unobs_y_t<=length(y_t) "The delay PMF must be shorter than or equal to the observation vector"
+    @assert unobs_y_t<=length(Y_t) "The delay PMF must be shorter than or equal to the observation vector"
 
     kernel = generate_observation_kernel(obs_model.pmf, nobs_Y_t)
     expected_obs = kernel * Y_t[unobs_y_t:end]
 
-    @submodel y_t_aux, obs_aux = generate_observations(
-        obs_model.model, y_t[unobs_y_t:end], expected_obs)
-
-    y_t[unobs_y_t:end] = y_t_aux
+    @submodel y_t, obs_aux = generate_observations(
+        obs_model.model, y_t, expected_obs)
 
     return y_t, (; obs_aux...)
 end

--- a/EpiAware/src/EpiObsModels/NegativeBinomialError.jl
+++ b/EpiAware/src/EpiObsModels/NegativeBinomialError.jl
@@ -56,8 +56,10 @@ Generate observations using the NegativeBinomialError observation model.
         y_t = Vector{Int}(undef, length(Y_t))
     end
 
-    for i in eachindex(y_t)
-        y_t[i] ~ NegativeBinomialMeanClust(
+    Y_y = length(y_t) - length(Y_t)
+
+    for i in eachindex(Y_t)
+        y_t[Y_y + i] ~ NegativeBinomialMeanClust(
             Y_t[i] + obs_model.pos_shift, sq_cluster_factor
         )
     end

--- a/EpiAware/src/EpiObsModels/PoissonError.jl
+++ b/EpiAware/src/EpiObsModels/PoissonError.jl
@@ -1,6 +1,7 @@
 @doc raw"
 The `PoissonError` struct represents an observation model for Poisson errors. It
-    is a subtype of `AbstractTuringObservationModel`.
+is a subtype of `AbstractTuringObservationModel`. Note that
+when Y_t is shorter than y_t, then the first `length(y_t) - length(Y_t)` elements of y_t are assumed to be missing.
 
 ## Constructors
 - `PoissonError(; pos_shift::AbstractFloat = 0.)`: Constructs a `PoissonError`

--- a/EpiAware/src/EpiObsModels/PoissonError.jl
+++ b/EpiAware/src/EpiObsModels/PoissonError.jl
@@ -40,9 +40,10 @@ Generate observations using the `PoissonError` observation model.
     if ismissing(y_t)
         y_t = Vector{Int}(undef, length(Y_t))
     end
+    Y_y = length(y_t) - length(Y_t)
 
     for i in eachindex(y_t)
-        y_t[i] ~ Poisson(Y_t[i] + obs_model.pos_shift)
+        y_t[Y_y + i] ~ Poisson(Y_t[i] + obs_model.pos_shift)
     end
 
     return y_t, NamedTuple()

--- a/EpiAware/test/EpiObsModels/LatentDelay.jl
+++ b/EpiAware/test/EpiObsModels/LatentDelay.jl
@@ -44,7 +44,7 @@ end
     fix_mdl = fix(mdl, (cluster_factor = neg_bin_cf,))
 
     n_samples = 1000
-    first_obs = sample(fix_mdl, Prior(), n_samples; progress = false) |>
+    first_obs = sample(mdl, Prior(), n_samples; progress = false) |>
                 chn -> generated_quantities(fix_mdl, chn) .|>
                        (gen -> gen[1][1]) |>
                        vec


### PR DESCRIPTION
This PR closes #183 by adding support for buffering in all currently supported observation models and in `LatentDelay`.

I am quite unhappy about the current approach because: 

- Requires support in all observation models that will be used with `LatentDelay`
- Has different behaviour when completely missing a vector of missingness is passed in


All that being said I think we should review this as a fix and use any major review comments in a new issue to improve this. One option we could consider is  no longer support passing just `y_t = missing` and instead enforce that this must be a empty vector (and helping people achieve this). Just this change would streamline at least part of this.