### PR TITLE
change default LatentDelay constructor to right truncation at 99th perc

### DIFF
--- a/EpiAware/src/EpiObsModels/LatentDelay.jl
+++ b/EpiAware/src/EpiObsModels/LatentDelay.jl
@@ -9,7 +9,13 @@ observed data.
 - `pmf::T`: The probability mass function (PMF) representing the delay distribution.
 
 ## Constructors
-- `LatentDelay(model::M, distribution::C; D = 15, Δd = 1.0) where {M <: AbstractTuringObservationModel, C <: ContinuousDistribution}`: Constructs a `LatentDelay` object with the given underlying observation model and continuous distribution. The `D` parameter specifies the number of discrete delay intervals, and the `Δd` parameter specifies the width of each delay interval.
+- `LatentDelay(model::M, distribution::C; D = 15, Δd = 1.0)
+    where {M <: AbstractTuringObservationModel, C <: ContinuousDistribution}`: Constructs
+    a `LatentDelay` object with the given underlying observation model and continuous
+    distribution. The `D` parameter specifies the right truncation of the distribution,
+    with default `D = nothing` indicating that the distribution should be truncated at its
+    99th percentile rounded to nearest integer. The `Δd` parameter specifies the
+    width of each delay interval.
 
 - `LatentDelay(model::M, pmf::T) where {M <: AbstractTuringObservationModel, T <: AbstractVector{<:Real}}`: Constructs a `LatentDelay` object with the given underlying observation model and delay PMF.
 
@@ -26,9 +32,12 @@ struct LatentDelay{M <: AbstractTuringObservationModel, T <: AbstractVector{<:Re
     model::M
     pmf::T
 
-    function LatentDelay(model::M, distribution::C; D = 15,
+    function LatentDelay(model::M, distribution::C; D = nothing,
             Δd = 1.0) where {
             M <: AbstractTuringObservationModel, C <: ContinuousDistribution}
+        if isnothing(D)
+            D = invlogcdf(distribution, log(0.99)) |> round
+        end
         pmf = censored_pmf(distribution; Δd = Δd, D = D)
         return LatentDelay(model, pmf)
     end

--- a/EpiAware/src/EpiObsModels/LatentDelay.jl
+++ b/EpiAware/src/EpiObsModels/LatentDelay.jl
@@ -9,7 +9,7 @@ observed data.
 - `pmf::T`: The probability mass function (PMF) representing the delay distribution.
 
 ## Constructors
-- `LatentDelay(model::M, distribution::C; D = 15, Δd = 1.0)
+- `LatentDelay(model::M, distribution::C; D = nothing, Δd = 1.0)
     where {M <: AbstractTuringObservationModel, C <: ContinuousDistribution}`: Constructs
     a `LatentDelay` object with the given underlying observation model and continuous
     distribution. The `D` parameter specifies the right truncation of the distribution,

--- a/EpiAware/test/EpiObsModels/LatentDelay.jl
+++ b/EpiAware/test/EpiObsModels/LatentDelay.jl
@@ -21,6 +21,16 @@
 
     @test obs_model.model == dummy_model
     @test length(obs_model.pmf) == D_delay
+
+    # Test case 3: check default right truncation
+    delay_distribution = Gamma(3, 15 / 3)
+    D_delay = nothing
+    Δd = 1.0
+
+    obs_model = LatentDelay(dummy_model, delay_distribution, D = D_delay, Δd = Δd)
+
+    nn_perc_rounded = invlogcdf(delay_distribution, log(0.99)) |> x -> round(Int64, x)
+    @test length(obs_model.pmf) == nn_perc_rounded
 end
 
 @testitem "Testing delay obs against theoretical properties" begin


### PR DESCRIPTION
I spotted that the default behaviour of the usual `LatentDelay` constructor was to have right truncation at 15 time steps irrespective of the underlying delay distribution. This is obviously a potential source of making silent errors.

This PR changes the constructor so that default of behaviour of this constructor is to calculate the 99th percentile of the observation distribution i.e.

```math
x_{99} = F^{(-1)}(0.99).
```
Where $F^{(-1)}$ is the inverse of the distribution function of the delay[^1]. And use the rounded value of $x_{99}$ as the right truncation value for the constructor.

[^1]: NB: the constructor is only defined for continuous delay distributions so this is always valid.