### PR TITLE
Make the 99th perc default constructor a `censored_pmf` feature

### DIFF
--- a/EpiAware/docs/src/examples/getting_started.jl
+++ b/EpiAware/docs/src/examples/getting_started.jl
@@ -201,16 +201,14 @@ md"
 
 `EpiAware` has an `EpiModel` type system which we use to set the behaviour of the latent infection model. In this case we want to implement a renewal model.
 
-To construct an `EpiModel` we need to supply some fixed data for the model contained in an `EpiData` object. The `EpiData` constructor performs double interval censoring to convert our _continuous_ estimate of the generation interval into a discretized version $g_t$. We also implement right truncation using the keyword `D_gen`.
-
+To construct an `EpiModel` we need to supply some fixed data for the model contained in an `EpiData` object. The `EpiData` constructor performs double interval censoring to convert our _continuous_ estimate of the generation interval into a discretized version $g_t$. We also implement right truncation, the default is rounding the 99th percentile of the generation interval distribution, but this can be controlled using the keyword `D_gen`.
 "
 
 # ╔═╡ c1fc1929-0624-45c0-9a89-86c8479b2675
 truth_GI = Gamma(6.5, 0.62)
 
 # ╔═╡ 99c9ba2c-20a5-4c7f-94d2-272d6c9d5904
-model_data = EpiData(gen_distribution = truth_GI,
-    D_gen = 14.0)
+model_data = EpiData(gen_distribution = truth_GI)
 
 # ╔═╡ 71d08f7e-c409-4fbe-b154-b21d09010683
 let

--- a/EpiAware/src/EpiInfModels/EpiData.jl
+++ b/EpiAware/src/EpiInfModels/EpiData.jl
@@ -52,7 +52,7 @@ struct EpiData{T <: Real, F <: Function}
     end
 
     function EpiData(; gen_distribution::ContinuousDistribution,
-            D_gen,
+            D_gen = nothing,
             Δd = 1.0,
             transformation::Function = exp)
         gen_int = censored_pmf(gen_distribution, Δd = Δd, D = D_gen) |>

--- a/EpiAware/src/EpiObsModels/LatentDelay.jl
+++ b/EpiAware/src/EpiObsModels/LatentDelay.jl
@@ -13,8 +13,8 @@ observed data.
     where {M <: AbstractTuringObservationModel, C <: ContinuousDistribution}`: Constructs
     a `LatentDelay` object with the given underlying observation model and continuous
     distribution. The `D` parameter specifies the right truncation of the distribution,
-    with default `D = nothing` indicating that the distribution should be truncated at its
-    99th percentile rounded to nearest integer. The `Δd` parameter specifies the
+    with default `D = nothing` indicates that the distribution should be truncated
+    at its 99th percentile rounded to nearest multiple of `Δd`. The `Δd` parameter specifies the
     width of each delay interval.
 
 - `LatentDelay(model::M, pmf::T) where {M <: AbstractTuringObservationModel, T <: AbstractVector{<:Real}}`: Constructs a `LatentDelay` object with the given underlying observation model and delay PMF.
@@ -35,9 +35,6 @@ struct LatentDelay{M <: AbstractTuringObservationModel, T <: AbstractVector{<:Re
     function LatentDelay(model::M, distribution::C; D = nothing,
             Δd = 1.0) where {
             M <: AbstractTuringObservationModel, C <: ContinuousDistribution}
-        if isnothing(D)
-            D = invlogcdf(distribution, log(0.99)) |> round
-        end
         pmf = censored_pmf(distribution; Δd = Δd, D = D)
         return LatentDelay(model, pmf)
     end

--- a/EpiAware/test/EpiAwareUtils/censored_pmf.jl
+++ b/EpiAware/test/EpiAwareUtils/censored_pmf.jl
@@ -45,4 +45,14 @@
         dist = Exponential(1.0)
         @test_throws AssertionError censored_pmf(dist, Δd = 1.0, D = 3.5)
     end
+
+    @testset "Test case 7: testing default choice of D" begin
+        dist = Exponential(1.0)
+        pmf = censored_pmf(dist, Δd = 1.0)
+        #Check the normalisation constant is > 0.99 for analytical solution
+        expected_pmf_uncond = [exp(-1)
+                               [(1 - exp(-1)) * (exp(1) - 1) * exp(-s)
+                                for s in 1:length(pmf)]]
+        @test sum(expected_pmf_uncond) > 0.99
+    end
 end


### PR DESCRIPTION
This is a small PR that follows on from #265. Whilst working on #256 I realised that #265 change should apply to both the observation and the discretised generation interval construction (this is useful when considering scenarios with different mean generation intervals).

This PR does this, plus adds a unit test. The unit tests to `LatentDelay` are unchanged because this default is now inherited from `censored_pmf`.

Slight modification is that the inferred `D` (right truncation value) is now rounded to nearest multiple of $\Delta d$ rather than integer.