### PR TITLE
QUICK FIX: fix InferenceConfig constructor for latest version of EpiAware

### DIFF
--- a/pipeline/src/infer/InferenceConfig.jl
+++ b/pipeline/src/infer/InferenceConfig.jl
@@ -19,7 +19,7 @@ struct InferenceConfig{T, F, I, L, E}
     "Latent model type."
     latent_model::L
     "Case data"
-    case_data::Union{Vector{Integer}, Missing}
+    case_data::Union{Vector{Integer,Missing}, Missing}
     "Time to fit on"
     tspan::Tuple{Integer, Integer}
     "Inference method."

--- a/pipeline/src/infer/InferenceConfig.jl
+++ b/pipeline/src/infer/InferenceConfig.jl
@@ -19,7 +19,7 @@ struct InferenceConfig{T, F, I, L, E}
     "Latent model type."
     latent_model::L
     "Case data"
-    case_data::Union{Vector{Integer,Missing}, Missing}
+    case_data::Union{Vector{Integer, Missing}, Missing}
     "Time to fit on"
     tspan::Tuple{Integer, Integer}
     "Inference method."


### PR DESCRIPTION
Small fix to make the inference functions work with latest version of `EpiAware`. This snuck into #282 but we might be modifying that PR.