### PR TITLE
update ADTypes in `EpiAware`

### DIFF
--- a/EpiAware/Project.toml
+++ b/EpiAware/Project.toml
@@ -25,7 +25,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
-ADTypes = "1.2"
+ADTypes = "1.3"
 AbstractMCMC = "5.2"
 AdvancedHMC = "0.6"
 DataFramesMeta = "0.15"

--- a/EpiAware/docs/Project.toml
+++ b/EpiAware/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 DataFramesMeta = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"

--- a/EpiAware/docs/src/examples/getting_started.jl
+++ b/EpiAware/docs/src/examples/getting_started.jl
@@ -385,7 +385,7 @@ num_threads = min(10, Threads.nthreads())
 # ╔═╡ 88b43e23-1e06-4716-b284-76e8afc6171b
 inference_method = EpiMethod(
     pre_sampler_steps = [ManyPathfinder(nruns = 4, maxiters = 100)],
-    sampler = NUTSampler(adtype = AutoReverseDiff(true),
+    sampler = NUTSampler(adtype = AutoReverseDiff(),
         ndraws = 2000,
         nchains = num_threads,
         mcmc_parallel = MCMCThreads())


### PR DESCRIPTION
This proposed fix to #302 is to update to `ADTypes` to 1.3 for `EpiAware` and pin the document environment to the same version as `EpiAware`

Closes #302 