### PR TITLE
Modify make_inference_configs

### DIFF
--- a/pipeline/src/constructors/make_inference_configs.jl
+++ b/pipeline/src/constructors/make_inference_configs.jl
@@ -12,17 +12,27 @@ function make_inference_configs(pipeline::AbstractEpiAwarePipeline; start = 21)
     gi_param_dict = make_gi_params(pipeline)
     namemodel_vect = make_epiaware_name_latentmodel_pairs(pipeline)
     igps = make_inf_generating_processes(pipeline)
+    _igps = filter(igp -> igp != Renewal, igps)
     obs = make_observation_model(pipeline)
     priors = make_model_priors(pipeline)
     default_params = make_default_params(pipeline)
     N = size(make_Rt(pipeline), 1)
     Ts = start:default_params["stride"]:N |> collect
 
-    inference_configs = Dict("igp" => igps, "latent_namemodels" => namemodel_vect,
+    renewal_configs = Renewal ∉ igps ? Dict[] :
+                      Dict("igp" => [Renewal], "latent_namemodels" => namemodel_vect,
         "observation_model" => obs, "gi_mean" => gi_param_dict["gi_means"],
         "gi_std" => gi_param_dict["gi_stds"], "log_I0_prior" => priors["log_I0_prior"],
-        "lookahead" => default_params["lookahead"], "lookback" => default_params["lookback"], "T" => Ts) |>
-                        dict_list
+        "lookahead" => default_params["lookahead"],
+        "lookback" => default_params["lookback"], "T" => Ts) |> dict_list
+
+    other_model_configs = Dict("igp" => _igps, "latent_namemodels" => namemodel_vect,
+        "observation_model" => obs, "gi_mean" => gi_param_dict["gi_means"][1:1],
+        "gi_std" => gi_param_dict["gi_stds"], "log_I0_prior" => priors["log_I0_prior"],
+        "lookahead" => default_params["lookahead"],
+        "lookback" => default_params["lookback"], "T" => Ts) |> dict_list
+
+    inference_configs = vcat(renewal_configs, other_model_configs)
 
     selected_inference_configs = _selector(inference_configs, pipeline)
     return selected_inference_configs


### PR DESCRIPTION
This small PR modifies `make_inference_configs` so there is no loop over `gi_mean` for non-Renewal models.

Closes #346.

NB: In this solution form the non-Renewal models still get passed a `gi_mean` value, so the effects of mis-specification will have to be a post-processing step.