### PR TITLE
new do_pipeline method for multiple scenarios

### DIFF
--- a/pipeline/src/constructors/make_inference_method.jl
+++ b/pipeline/src/constructors/make_inference_method.jl
@@ -32,7 +32,7 @@ end
 Pipeline test mode method for sampling from prior predictive distribution of the model.
 """
 function make_inference_method(
-        pipeline::EpiAwareExamplePipeline; ndraws::Integer = 2000,
+        pipeline::EpiAwareExamplePipeline; ndraws::Integer = 20,
         mcmc_ensemble::AbstractMCMC.AbstractMCMCEnsemble = MCMCThreads(),
         nruns_pthf::Integer = 4, maxiters_pthf::Integer = 100, nchains::Integer = 4)
     return EpiMethod(

--- a/pipeline/src/pipeline/do_pipeline.jl
+++ b/pipeline/src/pipeline/do_pipeline.jl
@@ -21,6 +21,8 @@ Perform the pipeline for each `AbstractEpiAwarePipeline` in the given vector `pi
 
 """
 function do_pipeline(pipelines::Vector{<:AbstractEpiAwarePipeline})
-    map(do_pipeline, pipelines)
+    map(pipelines) do pipeline
+        Dagger.@spawn do_pipeline(pipeline)
+    end
     return nothing
 end

--- a/pipeline/src/pipeline/do_pipeline.jl
+++ b/pipeline/src/pipeline/do_pipeline.jl
@@ -2,7 +2,7 @@
 Create a pipeline by generating truth data and making inferences.
 
 # Arguments
-- `pipeline::AbstractEpiAwarePipeline`: The pipeline object which sets pipeline behavior.
+- `pipeline::AbstractEpiAwarePipeline`: The pipeline object which sets pipeline behavior and scenario.
 
 """
 function do_pipeline(pipeline::AbstractEpiAwarePipeline)
@@ -10,5 +10,17 @@ function do_pipeline(pipeline::AbstractEpiAwarePipeline)
     for truthdata in truthdatas
         do_inference(truthdata, pipeline)
     end
+    return nothing
+end
+
+"""
+Perform the pipeline for each `AbstractEpiAwarePipeline` in the given vector `pipelines`.
+
+# Arguments
+- `pipelines`: A vector of `AbstractEpiAwarePipeline` objects.
+
+"""
+function do_pipeline(pipelines::Vector{<:AbstractEpiAwarePipeline})
+    map(do_pipeline, pipelines)
     return nothing
 end

--- a/pipeline/test/constructors/test_constructors.jl
+++ b/pipeline/test/constructors/test_constructors.jl
@@ -70,7 +70,7 @@ end
     @test method.pre_sampler_steps[1].maxiters == 100
     @test method.sampler isa NUTSampler
     @test method.sampler.adtype == AutoForwardDiff()
-    @test method.sampler.ndraws == 2000
+    @test method.sampler.ndraws == 20
     @test method.sampler.nchains == 4
     @test method.sampler.mcmc_parallel == MCMCThreads()
 end

--- a/pipeline/test/pipeline/test_pipelinefunctions.jl
+++ b/pipeline/test/pipeline/test_pipelinefunctions.jl
@@ -9,7 +9,7 @@
 end
 
 @testset "do_inference tests" begin
-    using EpiAwarePipeline, Dagger
+    using EpiAwarePipeline, Dagger, EpiAware
     pipeline = EpiAwareExamplePipeline()
 
     function make_inference()
@@ -28,5 +28,12 @@ end
     using EpiAwarePipeline
     pipeline = EpiAwareExamplePipeline()
     res = do_pipeline(pipeline)
+    @test isnothing(res)
+end
+
+@testset "do_pipeline test: just run as a vector" begin
+    using EpiAwarePipeline
+    pipelines = fill(EpiAwareExamplePipeline(), 2)
+    res = do_pipeline(pipelines)
     @test isnothing(res)
 end

--- a/pipeline/test/runtests.jl
+++ b/pipeline/test/runtests.jl
@@ -3,7 +3,7 @@ quickactivate(@__DIR__(), "EpiAwarePipeline")
 
 # Run tests
 include("pipeline/test_pipelinetypes.jl");
-# include("pipeline/test_pipelinefunctions.jl");
+include("pipeline/test_pipelinefunctions.jl");
 include("utils/test_calculate_processes.jl");
 include("constructors/test_constructors.jl");
 include("simulate/test_TruthSimulationConfig.jl");


### PR DESCRIPTION
This PR does the following things:

- Adds a `do_pipeline` method for ingesting multiple scenario pipelines and dispatching them sequentially.
- Reduces the number of `ndraws` in `EpiAwareExamplePipeline` dispatch on `make_inference_method` to just 20.
- Includes the pipeline function testing (which is now much faster).

The obvious caveat here is that `EpiAwareExamplePipeline` type is now aimed at checking code ability to run rather than inference correctness. This affects the purpose of the end-to-end tests and should be a new issue.

Closes #348 
