### PR TITLE
new `make_inference_method` to ingest parameters scenario struct

### DIFF
--- a/pipeline/src/constructors/make_inference_method.jl
+++ b/pipeline/src/constructors/make_inference_method.jl
@@ -42,3 +42,20 @@ function make_inference_method(
             nchains = nchains, mcmc_parallel = mcmc_ensemble)
     )
 end
+
+"""
+Constructs an inference method for the Rt-without-renewal pipeline.
+
+# Arguments
+- `pipeline`: An instance of the `AbstractRtwithoutRenewalPipeline` type.
+
+# Returns
+- An inference method for the pipeline.
+
+# Examples
+"""
+function make_inference_method(pipeline::AbstractRtwithoutRenewalPipeline)
+    return make_inference_method(pipeline; ndraws = pipeline.ndraws,
+        mcmc_ensemble = pipeline.mcmc_ensemble, nruns_pthf = pipeline.nruns_pthf,
+        maxiters_pthf = pipeline.maxiters_pthf, nchains = pipeline.nchains)
+end

--- a/pipeline/src/pipeline/pipelinetypes.jl
+++ b/pipeline/src/pipeline/pipelinetypes.jl
@@ -37,26 +37,46 @@ Rt = make_Rt(pipeline) |> Rt -> plot(Rt,
     title = "Smooth outbreak scenario")
 ```
 """
-struct SmoothOutbreakPipeline <: AbstractRtwithoutRenewalPipeline
+@kwdef struct SmoothOutbreakPipeline <: AbstractRtwithoutRenewalPipeline
+    ndraws::Integer = 2000
+    mcmc_ensemble::AbstractMCMC.AbstractMCMCEnsemble = MCMCSerial()
+    nruns_pthf::Integer = 4
+    maxiters_pthf::Integer = 100
+    nchains::Integer = 4
 end
 
 """
 The pipeline type for the Rt pipeline for an outbreak scenario where Rt has
     discontinuous changes over time due to implementation of measures.
 """
-struct MeasuresOutbreakPipeline <: AbstractRtwithoutRenewalPipeline
+@kwdef struct MeasuresOutbreakPipeline <: AbstractRtwithoutRenewalPipeline
+    ndraws::Integer = 2000
+    mcmc_ensemble::AbstractMCMC.AbstractMCMCEnsemble = MCMCSerial()
+    nruns_pthf::Integer = 4
+    maxiters_pthf::Integer = 100
+    nchains::Integer = 4
 end
 
 """
 The pipeline type for the Rt pipeline for an endemic scenario where Rt changes in
     a smooth sinusoidal manner over time.
 """
-struct SmoothEndemicPipeline <: AbstractRtwithoutRenewalPipeline
+@kwdef struct SmoothEndemicPipeline <: AbstractRtwithoutRenewalPipeline
+    ndraws::Integer = 2000
+    mcmc_ensemble::AbstractMCMC.AbstractMCMCEnsemble = MCMCSerial()
+    nruns_pthf::Integer = 4
+    maxiters_pthf::Integer = 100
+    nchains::Integer = 4
 end
 
 """
 The pipeline type for the Rt pipeline for an endemic scenario where Rt changes in
     a weekly-varying discontinuous manner over time.
 """
-struct RoughEndemicPipeline <: AbstractRtwithoutRenewalPipeline
+@kwdef struct RoughEndemicPipeline <: AbstractRtwithoutRenewalPipeline
+    ndraws::Integer = 2000
+    mcmc_ensemble::AbstractMCMC.AbstractMCMCEnsemble = MCMCSerial()
+    nruns_pthf::Integer = 4
+    maxiters_pthf::Integer = 100
+    nchains::Integer = 4
 end

--- a/pipeline/test/pipeline/test_pipelinefunctions.jl
+++ b/pipeline/test/pipeline/test_pipelinefunctions.jl
@@ -37,3 +37,13 @@ end
     res = do_pipeline(pipelines)
     @test isnothing(res)
 end
+
+@testset "do_pipeline test: main scenarios" begin
+    using EpiAwarePipeline
+    pipelines = [SmoothOutbreakPipeline(ndraws = 20, nchains = 1),
+        MeasuresOutbreakPipeline(ndraws = 20, nchains = 1),
+        SmoothEndemicPipeline(ndraws = 20, nchains = 1),
+        RoughEndemicPipeline(ndraws = 20, nchains = 1)]
+    res = do_pipeline(pipelines)
+    @test isnothing(res)
+end


### PR DESCRIPTION
This PR modifies the scenario definition types so that choices about the sampler are defined with the struct (defaults provided), and then ingested by a `make_inference_method` method.

Additionally, a new unit test for all 4 scenarios passed to `do_pipeline` is added.

This closes #352 .

### Main caveat

This PR introduces a different style of defining scenario behaviour, i.e. parameters of the struct instance rather than kwargs of the methods. This is understood to be somewhat confusing, but has turned out to be more convenient. The whole pipeline codebase should eventually move towards this style (IMO), maybe as part of #232.

