### PR TITLE
fix concatlatentmodel fail to construct vector of non-prefix models

### DIFF
--- a/EpiAware/src/EpiLatentModels/manipulators/ConcatLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/ConcatLatentModels.jl
@@ -44,15 +44,14 @@ struct ConcatLatentModels{
         @assert typeof(check_dim)<:AbstractVector{Int} "Output of dimension_adaptor must be a vector of integers"
         @assert length(check_dim)==no_models "The vector of dimensions must have the same length as the number of models"
         @assert length(prefixes)==no_models "The number of models and prefixes must be equal"
-        for i in eachindex(models)
-            if (prefixes[i] != "")
-                models[i] = PrefixLatentModel(models[i], prefixes[i])
-            end
+        prefixed_models = map(models, prefixes) do model, prefix
+            prefix == "" ? model : PrefixLatentModel(model, prefix)
         end
+
         return new{
-            AbstractVector{<:AbstractTuringLatentModel}, Int, Function,
+            typeof(prefixed_models), Int, Function,
             AbstractVector{<:String}}(
-            models, no_models, dimension_adaptor, prefixes)
+            prefixed_models, no_models, dimension_adaptor, prefixes)
     end
 
     function ConcatLatentModels(models::M, dimension_adaptor::Function;

--- a/EpiAware/test/EpiLatentModels/manipulators/ConcatLatentModels.jl
+++ b/EpiAware/test/EpiLatentModels/manipulators/ConcatLatentModels.jl
@@ -54,3 +54,12 @@ end
     @test con_model_out[2].intercept == 1.0
     @test con_model_out[2].nscale == 2.0
 end
+
+@testitem "ConcatLatentModels can combine hierarchical normals" begin
+    using Distributions
+    m1 = HierarchicalNormal(-0.1, truncated(Normal(0, 0.1), 0, Inf))
+    m2 = HierarchicalNormal(0.1, truncated(Normal(0, 0.1), 0, Inf))
+    ms = [m1, m2]
+    concat = ConcatLatentModels(ms)
+    @test concat isa ConcatLatentModels
+end


### PR DESCRIPTION
This fixes the bug identified #353 . The origin of the bug was a vector of models with defined eltype trying to write back into itself with a different eltype.

I've made the bug a unit test.

Closes #353