### PR TITLE
Issue 353: Use map to assign prefixes in modifier models

### DIFF
--- a/EpiAware/src/EpiLatentModels/manipulators/CombineLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/CombineLatentModels.jl
@@ -34,6 +34,8 @@ latent_model()
         prefix_models = map(eachindex(models)) do i
             if prefixes[i] != ""
                 PrefixLatentModel(models[i], prefixes[i])
+            else
+                models[i]
             end
         end
         return new{AbstractVector{<:AbstractTuringLatentModel}, AbstractVector{<:String}}(

--- a/EpiAware/src/EpiLatentModels/manipulators/CombineLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/CombineLatentModels.jl
@@ -31,13 +31,9 @@ latent_model()
             P <: AbstractVector{<:String}}
         @assert length(models)>1 "At least two models are required"
         @assert length(models)==length(prefixes) "The number of models and prefixes must be equal"
-        prefix_models = map(eachindex(models)) do i
-            if prefixes[i] != ""
-                PrefixLatentModel(models[i], prefixes[i])
-            else
-                models[i]
-            end
-        end
+        prefix_models = [prefixes[i] == "" ? models[i] :
+                         PrefixLatentModel(models[i], prefixes[i])
+                         for i in eachindex(models)]
         return new{AbstractVector{<:AbstractTuringLatentModel}, AbstractVector{<:String}}(
             prefix_models, prefixes)
     end

--- a/EpiAware/src/EpiLatentModels/manipulators/CombineLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/CombineLatentModels.jl
@@ -31,13 +31,13 @@ latent_model()
             P <: AbstractVector{<:String}}
         @assert length(models)>1 "At least two models are required"
         @assert length(models)==length(prefixes) "The number of models and prefixes must be equal"
-        for i in eachindex(models)
-            if (prefixes[i] != "")
-                models[i] = PrefixLatentModel(models[i], prefixes[i])
+        prefix_models = map(eachindex(models)) do i
+            if prefixes[i] != ""
+                PrefixLatentModel(models[i], prefixes[i])
             end
         end
         return new{AbstractVector{<:AbstractTuringLatentModel}, AbstractVector{<:String}}(
-            models, prefixes)
+            prefix_models, prefixes)
     end
 
     function CombineLatentModels(models::M) where {

--- a/EpiAware/src/EpiLatentModels/manipulators/ConcatLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/ConcatLatentModels.jl
@@ -47,6 +47,8 @@ struct ConcatLatentModels{
         prefix_models = map(eachindex(models)) do i
             if prefixes[i] != ""
                 PrefixLatentModel(models[i], prefixes[i])
+            else
+                models[i]
             end
         end
         return new{

--- a/EpiAware/src/EpiLatentModels/manipulators/ConcatLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/ConcatLatentModels.jl
@@ -44,13 +44,9 @@ struct ConcatLatentModels{
         @assert typeof(check_dim)<:AbstractVector{Int} "Output of dimension_adaptor must be a vector of integers"
         @assert length(check_dim)==no_models "The vector of dimensions must have the same length as the number of models"
         @assert length(prefixes)==no_models "The number of models and prefixes must be equal"
-        prefix_models = map(eachindex(models)) do i
-            if prefixes[i] != ""
-                PrefixLatentModel(models[i], prefixes[i])
-            else
-                models[i]
-            end
-        end
+        prefix_models = [prefixes[i] == "" ? models[i] :
+                         PrefixLatentModel(models[i], prefixes[i])
+                         for i in eachindex(models)]
         return new{
             AbstractVector{<:AbstractTuringLatentModel}, Int, Function,
             AbstractVector{<:String}}(

--- a/EpiAware/src/EpiLatentModels/manipulators/ConcatLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/ConcatLatentModels.jl
@@ -44,15 +44,15 @@ struct ConcatLatentModels{
         @assert typeof(check_dim)<:AbstractVector{Int} "Output of dimension_adaptor must be a vector of integers"
         @assert length(check_dim)==no_models "The vector of dimensions must have the same length as the number of models"
         @assert length(prefixes)==no_models "The number of models and prefixes must be equal"
-        for i in eachindex(models)
-            if (prefixes[i] != "")
-                models[i] = PrefixLatentModel(models[i], prefixes[i])
+        prefix_models = map(eachindex(models)) do i
+            if prefixes[i] != ""
+                PrefixLatentModel(models[i], prefixes[i])
             end
         end
         return new{
             AbstractVector{<:AbstractTuringLatentModel}, Int, Function,
             AbstractVector{<:String}}(
-            models, no_models, dimension_adaptor, prefixes)
+            prefix_models, no_models, dimension_adaptor, prefixes)
     end
 
     function ConcatLatentModels(models::M, dimension_adaptor::Function;

--- a/EpiAware/src/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
+++ b/EpiAware/src/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
@@ -30,11 +30,13 @@ struct Ascertainment{
             latent_prefix::P) where {
             M <: AbstractTuringObservationModel, T <: AbstractTuringLatentModel,
             F <: Function, P <: String}
-        if (latent_prefix != "")
-            latent_model = PrefixLatentModel(latent_model, latent_prefix)
+        prefix_model = if latent_prefix == ""
+            latent_model
+        else
+            PrefixLatentModel(latent_model, latent_prefix)
         end
         return new{M, AbstractTuringLatentModel, F, P}(
-            model, latent_model, link, latent_prefix)
+            model, prefix_model, link, latent_prefix)
     end
 
     function Ascertainment(model::M,

--- a/EpiAware/src/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
+++ b/EpiAware/src/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
@@ -30,11 +30,8 @@ struct Ascertainment{
             latent_prefix::P) where {
             M <: AbstractTuringObservationModel, T <: AbstractTuringLatentModel,
             F <: Function, P <: String}
-        prefix_model = if latent_prefix == ""
-            latent_model
-        else
-            PrefixLatentModel(latent_model, latent_prefix)
-        end
+        prefix_model = latent_prefix == "" ? latent_model :
+                       PrefixLatentModel(latent_model, latent_prefix)
         return new{M, AbstractTuringLatentModel, F, P}(
             model, prefix_model, link, latent_prefix)
     end

--- a/EpiAware/test/EpiLatentModels/manipulators/CombineLatentModels.jl
+++ b/EpiAware/test/EpiLatentModels/manipulators/CombineLatentModels.jl
@@ -16,6 +16,17 @@
     @test comb.prefixes == ["Int", "AR"]
 end
 
+@testitem "CombineLatentModels constructor handles duplicate models" begin
+    using Distributions: Normal
+    comb = CombineLatentModels([Intercept(Normal(0, 1)), Intercept(Normal(0, 2))])
+    prefix_1 = PrefixLatentModel(Intercept(Normal(0, 1)), "Combine.1")
+    prefix_2 = PrefixLatentModel(Intercept(Normal(0, 2)), "Combine.2")
+
+    @test typeof(comb) <: AbstractTuringLatentModel
+    @test comb.models == [prefix_1, prefix_2]
+    @test comb.prefixes == ["Combine.1", "Combine.2"]
+end
+
 @testitem "CombineLatentModels generate_latent method works as expected: FixedIntecept + custom" begin
     using Turing
 

--- a/EpiAware/test/EpiLatentModels/manipulators/ConcatLatentModels.jl
+++ b/EpiAware/test/EpiLatentModels/manipulators/ConcatLatentModels.jl
@@ -32,6 +32,19 @@
     @test concat_prefix.prefixes == ["Int", "AR"]
 end
 
+@testitem "ConcatLatentmodels constructor works with duplicate models" begin
+    using Distributions: Normal
+    concat = ConcatLatentModels([Intercept(Normal(0, 1)), Intercept(Normal(0, 2))])
+    prefix_1 = PrefixLatentModel(Intercept(Normal(0, 1)), "Concat.1")
+    prefix_2 = PrefixLatentModel(Intercept(Normal(0, 2)), "Concat.2")
+
+    @test typeof(concat) <: AbstractTuringLatentModel
+    @test concat.models == [prefix_1, prefix_2]
+    @test concat.no_models == 2
+    @test concat.dimension_adaptor == equal_dimensions
+    @test concat.prefixes == ["Concat.1", "Concat.2"]
+end
+
 @testitem "ConcatLatentModels generate_latent method works as expected: FixedIntecept + custom" begin
     using Turing
 


### PR DESCRIPTION
This PR closes #353 by using `map` vs a for loop to create a new vector of `prefix_models`. I have updated `CombineLatentModels`, `ConcatLatentModels`, and `Ascertainment` and added new tests for `CombineLatentModels` and `ConcatLatentModels` that demonstrate the fix working as expected.