### PR TITLE
Issue 364: Remove Zygote from benchmarks

### DIFF
--- a/benchmark/bench/EpiInfModels/DirectInfections.jl
+++ b/benchmark/bench/EpiInfModels/DirectInfections.jl
@@ -13,5 +13,5 @@ let
     expected_incidence = exp.(log_init_scale .+ log_incidence)
 
     mdl = generate_latent_infs(direct_inf_model, log_incidence)
-    suite["DirectInfections"] = make_turing_suite(mdl; check = true)
+    suite["DirectInfections"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiInfModels/EpiInfModels.jl
+++ b/benchmark/bench/EpiInfModels/EpiInfModels.jl
@@ -3,6 +3,7 @@ module BenchEpiInfModels
 using BenchmarkTools, TuringBenchmarking, EpiAware, Distributions
 suite = BenchmarkGroup()
 
+include("../../make_epiaware_suite.jl")
 include("DirectInfections.jl")
 include("ExpGrowthRate.jl")
 

--- a/benchmark/bench/EpiInfModels/ExpGrowthRate.jl
+++ b/benchmark/bench/EpiInfModels/ExpGrowthRate.jl
@@ -13,5 +13,5 @@ let
     rt = [log(recent_incidence[1]) - log_init; diff(log.(recent_incidence))]
 
     mdl = generate_latent_infs(rt_model, rt)
-    suite["ExpGrowthRate"] = make_turing_suite(mdl; check = true)
+    suite["ExpGrowthRate"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiInfModels/Renewal.jl
+++ b/benchmark/bench/EpiInfModels/Renewal.jl
@@ -12,7 +12,7 @@ let
     log_Rt = log.(Rt)
     initial_incidence = [1.0, 1.0, 1.0]#aligns with initial exp growth rate of 0.
     mdl = generate_latent_infs(renewal_model, log_Rt)
-    suite["Renewal"] = make_turing_suite(mdl; check = true)
+    suite["Renewal"] = make_epiaware_suite(mdl)
 end
 
 # Error:  ArgumentError: Converting an instance of ReverseDiff.TrackedReal{Float64, Float64, Nothing} to Float64 is not defined. Please use `ReverseDiff.value` instead.
@@ -30,5 +30,5 @@ let
     Rt = [1.0, 1.2, 1.5, 1.5, 1.5]
     log_Rt = log.(Rt)
     mdl = generate_latent_infs(renewal_model, log_Rt)
-    suite["RenewalWithPopulation"] = make_turing_suite(mdl; check = true)
+    suite["RenewalWithPopulation"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/EpiLatentModels.jl
+++ b/benchmark/bench/EpiLatentModels/EpiLatentModels.jl
@@ -3,6 +3,7 @@ module BenchEpiLatentModels
 using BenchmarkTools, TuringBenchmarking, EpiAware, DynamicPPL
 suite = BenchmarkGroup()
 
+include("../../make_epiaware_suite.jl")
 include("models/AR.jl")
 include("models/RandomWalk.jl")
 include("models/Intercept.jl")

--- a/benchmark/bench/EpiLatentModels/manipulators/CombineLatentModels.jl
+++ b/benchmark/bench/EpiLatentModels/manipulators/CombineLatentModels.jl
@@ -4,5 +4,5 @@ let
     ns = AR()
     con = CombineLatentModels([s, ns])
     mdl = generate_latent(con, 10)
-    suite["CombineLatentModels"] = make_turing_suite(mdl; check = true)
+    suite["CombineLatentModels"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/manipulators/ConcatLatentModels.jl
+++ b/benchmark/bench/EpiLatentModels/manipulators/ConcatLatentModels.jl
@@ -4,5 +4,5 @@ let
     ns = RandomWalk()
     con = ConcatLatentModels([s, ns])
     mdl = generate_latent(con, 10)
-    suite["ConcatLatentModels"] = make_turing_suite(mdl; check = false)
+    suite["ConcatLatentModels"] = make_epiaware_suite(mdl; check = false)
 end

--- a/benchmark/bench/EpiLatentModels/manipulators/broadcast/LatentModel.jl
+++ b/benchmark/bench/EpiLatentModels/manipulators/broadcast/LatentModel.jl
@@ -1,5 +1,5 @@
 let
     model = BroadcastLatentModel(RandomWalk(), 5, RepeatBlock())
     broadcasted_model = generate_latent(model, 10)
-    suite["BroadcastLatentModel"] = make_turing_suite(broadcasted_model; check = true)
+    suite["BroadcastLatentModel"] = make_epiaware_suite(broadcasted_model)
 end

--- a/benchmark/bench/EpiLatentModels/manipulators/broadcast/helpers.jl
+++ b/benchmark/bench/EpiLatentModels/manipulators/broadcast/helpers.jl
@@ -2,12 +2,12 @@ let
     model = RandomWalk()
     broadcast_model = broadcast_dayofweek(model)
     mdl = generate_latent(broadcast_model, 10)
-    suite["broadcast_dayofweek"] = make_turing_suite(mdl; check = true)
+    suite["broadcast_dayofweek"] = make_epiaware_suite(mdl)
 end
 
 let
     model = AR()
     broadcast_model = broadcast_weekly(model)
     mdl = generate_latent(broadcast_model, 10)
-    suite["broadcast_weekly"] = make_turing_suite(mdl; check = true)
+    suite["broadcast_weekly"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/models/AR.jl
+++ b/benchmark/bench/EpiLatentModels/models/AR.jl
@@ -1,5 +1,5 @@
 let
     latent = AR()
     mdl = generate_latent(latent, 10)
-    suite["AR"] = make_turing_suite(mdl; check = true)
+    suite["AR"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/models/FixedIntercept.jl
+++ b/benchmark/bench/EpiLatentModels/models/FixedIntercept.jl
@@ -6,5 +6,5 @@ let
         return y
     end
     mdl = model(10)
-    suite["Intercept"] = make_turing_suite(mdl; check = true)
+    suite["Intercept"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/models/HierarchicalNormal.jl
+++ b/benchmark/bench/EpiLatentModels/models/HierarchicalNormal.jl
@@ -1,5 +1,5 @@
 let
     latent = HierarchicalNormal()
     mdl = generate_latent(latent, 10)
-    suite["HierarchicalNormal"] = make_turing_suite(mdl; check = true)
+    suite["HierarchicalNormal"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/models/Intercept.jl
+++ b/benchmark/bench/EpiLatentModels/models/Intercept.jl
@@ -2,5 +2,5 @@ let
     using Distributions
     latent = Intercept(Normal(0, 1))
     mdl = generate_latent(latent, 10)
-    suite["Intercept"] = make_turing_suite(mdl; check = true)
+    suite["Intercept"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/models/RandomWalk.jl
+++ b/benchmark/bench/EpiLatentModels/models/RandomWalk.jl
@@ -1,5 +1,5 @@
 let
     latent = RandomWalk()
     mdl = generate_latent(latent, 10)
-    suite["RandomWalk"] = make_turing_suite(mdl; check = true)
+    suite["RandomWalk"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/modifiers/DiffLatentModel.jl
+++ b/benchmark/bench/EpiLatentModels/modifiers/DiffLatentModel.jl
@@ -7,5 +7,5 @@ let
     diff_model = DiffLatentModel(model = rw_model, init_priors = init_priors)
 
     latent_model = generate_latent(diff_model, n)
-    suite["DiffLatentModel"] = make_turing_suite(latent_model; check = true)
+    suite["DiffLatentModel"] = make_epiaware_suite(latent_model)
 end

--- a/benchmark/bench/EpiLatentModels/modifiers/PrefixLatentModel.jl
+++ b/benchmark/bench/EpiLatentModels/modifiers/PrefixLatentModel.jl
@@ -1,5 +1,5 @@
 let
     prefix_mdl = PrefixLatentModel(model = HierarchicalNormal(), prefix = "Test")
     mdl = generate_latent(prefix_mdl, 10)
-    suite["PrefixLatentModel"] = make_turing_suite(mdl; check = true)
+    suite["PrefixLatentModel"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiLatentModels/modifiers/TransformLatentModel.jl
+++ b/benchmark/bench/EpiLatentModels/modifiers/TransformLatentModel.jl
@@ -3,5 +3,5 @@ let
 
     trans = TransformLatentModel(Intercept(Normal(2, 0.2)), x -> x .|> exp)
     mdl = generate_latent(trans, 5)
-    suite["TransformLatentModel"] = make_turing_suite(mdl; check = true)
+    suite["TransformLatentModel"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiObsModels/EpiObsModels.jl
+++ b/benchmark/bench/EpiObsModels/EpiObsModels.jl
@@ -3,6 +3,7 @@ module BenchEpiObsModels
 using BenchmarkTools, TuringBenchmarking, EpiAware, DynamicPPL
 suite = BenchmarkGroup()
 
+include("../../make_epiaware_suite.jl")
 include("modifiers/ascertainment/Ascertainment.jl")
 include("modifiers/ascertainment/helpers.jl")
 include("modifiers/LatentDelay.jl")

--- a/benchmark/bench/EpiObsModels/ObservationErrorModels/NegativeBinomialError.jl
+++ b/benchmark/bench/EpiObsModels/ObservationErrorModels/NegativeBinomialError.jl
@@ -4,5 +4,5 @@ let
     nb_obs_model = NegativeBinomialError()
     Y_t = fill(μ, n)
     model = generate_observations(nb_obs_model, Y_t, Y_t)
-    suite["NegativeBinomialError"] = make_turing_suite(model; check = true)
+    suite["NegativeBinomialError"] = make_epiaware_suite(model)
 end

--- a/benchmark/bench/EpiObsModels/ObservationErrorModels/PoissonError.jl
+++ b/benchmark/bench/EpiObsModels/ObservationErrorModels/PoissonError.jl
@@ -9,5 +9,5 @@ let
         @submodel generate_observations(nb_obs_model, Y_t, μ)
     end
     mdl = test_model(Y_t, n)
-    suite["PoissonError"] = make_turing_suite(mdl; check = true)
+    suite["PoissonError"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiObsModels/ObservationErrorModels/methods.jl
+++ b/benchmark/bench/EpiObsModels/ObservationErrorModels/methods.jl
@@ -19,13 +19,13 @@ let
     I_t = [10.0, 20.0, 30.0, 40.0, 50.0]
     mdl = generate_observations(obs_model, missing, I_t)
 
-    suite["observation_error"]["missing obs"] = make_turing_suite(mdl; check = false)
+    suite["observation_error"]["missing obs"] = make_epiaware_suite(mdl; check = false)
 
     missing_I_t = vcat(missing, I_t)
     mdl2 = generate_observations(obs_model, missing_I_t, vcat(20, I_t))
-    suite["observation_error"]["partially missing obs"] = make_turing_suite(
+    suite["observation_error"]["partially missing obs"] = make_epiaware_suite(
         mdl2; check = false)
 
     mdl3 = generate_observations(obs_model, I_t, I_t)
-    suite["observation_error"]["no missing obs"] = make_turing_suite(mdl3; check = true)
+    suite["observation_error"]["no missing obs"] = make_epiaware_suite(mdl3)
 end

--- a/benchmark/bench/EpiObsModels/StackObservationModels.jl
+++ b/benchmark/bench/EpiObsModels/StackObservationModels.jl
@@ -8,5 +8,5 @@ let
 
     gen_obs = generate_observations(obs, y_t, Y_t)
 
-    suite["StackObservationModels"] = make_turing_suite(gen_obs; check = false)
+    suite["StackObservationModels"] = make_epiaware_suite(gen_obs; check = false)
 end

--- a/benchmark/bench/EpiObsModels/modifiers/LatentDelay.jl
+++ b/benchmark/bench/EpiObsModels/modifiers/LatentDelay.jl
@@ -2,5 +2,5 @@ let
     I_t = fill(10, 100)
     delay_obs = LatentDelay(NegativeBinomialError(), [0.1, 0.2, 0.3, 0.4])
     mdl = generate_observations(delay_obs, I_t, I_t)
-    suite["LatentDelay"] = make_turing_suite(mdl; check = true)
+    suite["LatentDelay"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiObsModels/modifiers/PrefixObservationModel.jl
+++ b/benchmark/bench/EpiObsModels/modifiers/PrefixObservationModel.jl
@@ -1,5 +1,5 @@
 let
     model = PrefixObservationModel(model = NegativeBinomialError(), prefix = "Test")
     mdl = generate_observations(model, 9, 10)
-    suite["PrefixObservationModel"] = make_turing_suite(mdl; check = true)
+    suite["PrefixObservationModel"] = make_epiaware_suite(mdl)
 end

--- a/benchmark/bench/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
+++ b/benchmark/bench/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
@@ -2,5 +2,5 @@ let
     obs = Ascertainment(NegativeBinomialError(), FixedIntercept(0.1); link = x -> x)
     I_t = fill(100, 10)
     gen_obs = generate_observations(obs, I_t, I_t)
-    suite["Ascertainment"] = make_turing_suite(gen_obs; check = true)
+    suite["Ascertainment"] = make_epiaware_suite(gen_obs)
 end

--- a/benchmark/bench/EpiObsModels/modifiers/ascertainment/helpers.jl
+++ b/benchmark/bench/EpiObsModels/modifiers/ascertainment/helpers.jl
@@ -4,5 +4,5 @@ let
     nweeks = 2
     I_t = fill(incidence_each_ts, nweeks * 7)
     obs_model = generate_observations(obs, I_t, I_t)
-    suite["ascertainment_dayofweek"] = make_turing_suite(obs_model; check = true)
+    suite["ascertainment_dayofweek"] = make_epiaware_suite(obs_model)
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,4 +1,5 @@
 using BenchmarkTools
+
 SUITE = BenchmarkGroup()
 for folder in readdir(joinpath(@__DIR__, "bench"))
     if isdir(joinpath(@__DIR__, "bench", folder))

--- a/benchmark/make_epiaware_suite.jl
+++ b/benchmark/make_epiaware_suite.jl
@@ -1,0 +1,9 @@
+"""
+   A custom wrapper for the `TuringBenchmarking.make_turing_suite` that adds EpiAware specific defaults.
+"""
+function make_epiaware_suite(model; check = true,
+        adbackends = [:forwarddiff, :reversediff, :reversediff_compiled])
+    suite = TuringBenchmarking.make_turing_suite(
+        model; check = check, adbackends = adbackends)
+    return suite
+end

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -7,6 +7,5 @@ benchmarkpkg(
         "OMP_NUM_THREADS" => "2"
     ),
     );
-    resultfile = joinpath(@__DIR__, "result.json"),
     retune = true
 )


### PR DESCRIPTION
This PR closes #364 by removing Zygote from all Turing benchmarks. It does this by making a custom `EpiAware` wrapper around `TuringBenchmarking.make_turing_suite()` that sets some defaults (i.e clean is true and the backends we are testing vs they are). 

The downside of this change is we will need to watch their defaults/use to see if they think its time to test a new backend.