### PR TITLE
Issue 340: Simplify LatentDelay

### DIFF
--- a/EpiAware/src/EpiObsModels/EpiObsModels.jl
+++ b/EpiAware/src/EpiObsModels/EpiObsModels.jl
@@ -5,11 +5,11 @@ module EpiObsModels
 
 using ..EpiAwareBase
 
-using ..EpiAwareUtils: censored_pmf, HalfNormal, prefix_submodel
+using ..EpiAwareUtils
 
 using ..EpiLatentModels: HierarchicalNormal, broadcast_dayofweek, PrefixLatentModel
 
-using Turing, Distributions, DocStringExtensions, SparseArrays
+using Turing, Distributions, DocStringExtensions, SparseArrays, LinearAlgebra
 
 # Observation error models
 export PoissonError, NegativeBinomialError

--- a/EpiAware/test/EpiObsModels/modifiers/LatentDelay.jl
+++ b/EpiAware/test/EpiObsModels/modifiers/LatentDelay.jl
@@ -10,7 +10,7 @@
     obs_model = LatentDelay(dummy_model, delay_int)
 
     @test obs_model.model == dummy_model
-    @test obs_model.pmf == delay_int
+    @test obs_model.rev_pmf == reverse(delay_int)
 
     # Test case 2
     delay_distribution = Uniform(0.0, 20.0)
@@ -20,7 +20,7 @@
     obs_model = LatentDelay(dummy_model, delay_distribution, D = D_delay, Δd = Δd)
 
     @test obs_model.model == dummy_model
-    @test length(obs_model.pmf) == D_delay
+    @test length(obs_model.rev_pmf) == D_delay
 
     # Test case 3: check default right truncation
     delay_distribution = Gamma(3, 15 / 3)
@@ -30,7 +30,7 @@
     obs_model = LatentDelay(dummy_model, delay_distribution, D = D_delay, Δd = Δd)
 
     nn_perc_rounded = invlogcdf(delay_distribution, log(0.99)) |> x -> round(Int64, x)
-    @test length(obs_model.pmf) == nn_perc_rounded
+    @test length(obs_model.rev_pmf) == nn_perc_rounded
 end
 
 @testitem "Testing delay obs against theoretical properties" begin
@@ -129,7 +129,7 @@ end
     obs_model = LatentDelay(TestObs(), delay_int)
 
     I_t = [10.0, 20.0, 30.0, 40.0, 50.0]
-    expected_obs = [missing, missing, 23.0, 33.0, 43.0]
+    expected_obs = [missing, missing, 17.0, 27.0, 37.0]
 
     @testset "Test with entirely missing data" begin
         mdl = generate_observations(obs_model, missing, I_t)


### PR DESCRIPTION
This PR targets but may not close #340. It may also help with #357.

It simplifies the `LatentDelay` approach to use a dot product-based method rather than the current sparse matrix approach. It keeps the sparse matrix constructor as this may be useful in #386 (and generally changes here are temporary as #386 will likely improve this implementation substantially.

I initially implemented this as a simple map but then decided  to implement using the `accumulate_scan` framework as a test. That resulted in a bit more code overhead and complexity but maybe worth it for consistency. It definitely works in this setting though and confirms my belief that it will work for composable modelling in #385 


