### PR TITLE
LatentDelay passes a view of the obs into comparison with expected_obs -- do not merge

### DIFF
--- a/EpiAware/src/EpiObsModels/modifiers/LatentDelay.jl
+++ b/EpiAware/src/EpiObsModels/modifiers/LatentDelay.jl
@@ -72,10 +72,11 @@ Generates observations based on the `LatentDelay` observation model.
         vcat(trunc_Y_t[(pmf_length + 1):end], 0.0)
     )
 
-    complete_obs = vcat(fill(missing, pmf_length + first_Y_t - 2), expected_obs)
-
+    # complete_obs = vcat(fill(missing, pmf_length + first_Y_t - 2), expected_obs)
+    m = size(expected_obs, 1)
+    _y_t = ismissing(y_t) ? missing : @view y_t[(end - m + 1):end]
     @submodel y_t = generate_observations(
-        obs_model.model, y_t, complete_obs)
+        obs_model.model, _y_t, expected_obs)
 
     return y_t
 end


### PR DESCRIPTION
This draft looks at a very quick fix to the problem noted in #357 without making a confident claim that this is the best way forward.

The simple idea is to only pass along case obs `y_t` that aren't affected by left truncation and compare against `expected_obs`.

The upside is that this fixes the MRE of the error I found in #357 for reversediff and compiled reversediff by avoiding constructing arrays with eltypes that are not a subtype of `Real`. The downsides are it causing fails among unit tests that are expecting that kind of input/output _and_ unassessed potential interactions with `Ascertainment`.

This PR is more for reasoning on this rather than a target for merging.