### PR TITLE
Issue 251: Add aggregation functionality

### DIFF
--- a/EpiAware/src/EpiLatentModels/EpiLatentModels.jl
+++ b/EpiAware/src/EpiLatentModels/EpiLatentModels.jl
@@ -23,7 +23,7 @@ export CombineLatentModels, ConcatLatentModels, BroadcastLatentModel
 export RepeatEach, RepeatBlock
 
 # Export helper functions
-export broadcast_dayofweek, broadcast_weekly, equal_dimensions
+export broadcast_rule, broadcast_dayofweek, broadcast_weekly, equal_dimensions
 
 # Export tools for modifying latent models
 export DiffLatentModel, TransformLatentModel, PrefixLatentModel, RecordExpectedLatent

--- a/EpiAware/src/EpiLatentModels/manipulators/broadcast/LatentModel.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/broadcast/LatentModel.jl
@@ -51,7 +51,6 @@ Generates latent periods using the specified `model` and `n` number of samples.
 
 ## Returns
 - `broadcasted_latent`: The generated broadcasted latent periods.
-- `latent_period_aux...`: Additional auxiliary information about the latent periods.
 
 "
 @model function EpiAwareBase.generate_latent(model::BroadcastLatentModel, n)

--- a/EpiAware/src/EpiLatentModels/manipulators/broadcast/rules.jl
+++ b/EpiAware/src/EpiLatentModels/manipulators/broadcast/rules.jl
@@ -7,7 +7,7 @@ It repeats the latent process at each period. An example of this rule is to repe
 ```julia
 using EpiAware
 rule = RepeatEach()
-latent = [1, 2, 3]
+latent = [1, 2]
 n = 10
 period = 2
 broadcast_rule(rule, latent, n, period)

--- a/EpiAware/src/EpiObsModels/EpiObsModels.jl
+++ b/EpiAware/src/EpiObsModels/EpiObsModels.jl
@@ -7,7 +7,8 @@ using ..EpiAwareBase
 
 using ..EpiAwareUtils
 
-using ..EpiLatentModels: HierarchicalNormal, broadcast_dayofweek, PrefixLatentModel
+using ..EpiLatentModels: HierarchicalNormal, broadcast_dayofweek
+using ..EpiLatentModels: broadcast_rule, PrefixLatentModel, RepeatEach
 
 using Turing, Distributions, DocStringExtensions, SparseArrays, LinearAlgebra
 
@@ -19,6 +20,7 @@ export generate_observation_error_priors, observation_error
 
 # Observation model modifiers
 export LatentDelay, Ascertainment, PrefixObservationModel, RecordExpectedObs
+export Aggregate
 
 # Observation model manipulators
 export StackObservationModels
@@ -30,6 +32,7 @@ include("docstrings.jl")
 include("modifiers/LatentDelay.jl")
 include("modifiers/ascertainment/Ascertainment.jl")
 include("modifiers/ascertainment/helpers.jl")
+include("modifiers/Aggregate.jl")
 include("modifiers/PrefixObservationModel.jl")
 include("modifiers/RecordExpectedObs.jl")
 include("StackObservationModels.jl")

--- a/EpiAware/src/EpiObsModels/modifiers/Aggregate.jl
+++ b/EpiAware/src/EpiObsModels/modifiers/Aggregate.jl
@@ -42,7 +42,7 @@ end
 
 @model function EpiAwareBase.generate_observations(ag::Aggregate, y_t, Y_t)
     if ismissing(y_t)
-        y_t = fill(0.0, length(Y_t))
+        y_t = Vector{Missing}(missing, length(Y_t))
     end
 
     n = length(y_t)

--- a/EpiAware/src/EpiObsModels/modifiers/ascertainment/Aggregate.jl
+++ b/EpiAware/src/EpiObsModels/modifiers/ascertainment/Aggregate.jl
@@ -1,0 +1,34 @@
+struct Aggregate{M <: AbstractTuringLatentModel,} <: AbstractTuringLatentModel
+    model::M
+    aggregation = [0, 7, 0, 0, 0, 0, 0]
+    present = [false, true, false, false, false, false, false]
+end
+
+@model function EpiAwareBase.generate_observations(ag::Aggregate, y_t, Y_t)
+    if ismissing(y_t)
+        y_t = Vector{Real}(0.0, length(Y_t))
+    end
+
+    n = length(y_t)
+    m = length(ag.aggregation)
+
+    aggregation = broadcast_n(RepeatEach(), ag.aggregation, n, m)
+    present = broadcast_n(RepeatEach(), ag.present, n, m)
+
+    agg_Y_t = map(eachindex(aggregation)) do i
+        if present[i]
+            exp_Y_t = sum(Y_t[min(1, i - aggregation[i] + 1):i])
+        else
+            exp_Y_t = 0.0
+        end
+        return exp_Y_t
+    end
+
+    @submodel exp_obs = generate_observations(ag.model, y_t[present], agg_Y_t[present])
+    return _return_aggregate(exp_obs, y_t, present)
+end
+
+function _return_aggregate(exp_obs, y_t, present)
+    y_t[present] = exp_obs
+    return y_t
+end

--- a/EpiAware/test/EpiObsModels/modifiers/Aggregate.jl
+++ b/EpiAware/test/EpiObsModels/modifiers/Aggregate.jl
@@ -1,0 +1,30 @@
+@testitem "Aggregate constructor works as expected" begin
+    weekly_agg = Aggregate(PoissonError(), [0, 0, 0, 0, 7, 0, 0])
+    @test weekly_agg.model == PoissonError()
+    @test weekly_agg.aggregation == [0, 0, 0, 0, 7, 0, 0]
+    @test weekly_agg.present == [false, false, false, false, true, false, false]
+
+    weekly_agg = Aggregate(model = PoissonError(), aggregation = [0, 0, 0, 0, 7, 0, 0])
+    @test weekly_agg.model == PoissonError()
+    @test weekly_agg.aggregation == [0, 0, 0, 0, 7, 0, 0]
+end
+
+@testitem "Aggregate generate_observations works as expected" begin
+    using Turing
+    struct TestObs <: AbstractTuringObservationModel end
+
+    @model function EpiAwareBase.generate_observations(::TestObs, y_t, Y_t)
+        return Y_t
+    end
+    weekly_agg = Aggregate(TestObs(), [0, 0, 0, 0, 7, 0, 0])
+    gen_obs = generate_observations(weekly_agg, missing, fill(1, 28))
+    draws = gen_obs()
+    @test draws isa Vector{Float64}
+    @test length(draws) == 28
+    exp_draws = fill(0.0, 28)
+    exp_draws[5] = 5.0
+    exp_draws[12] = 7.0
+    exp_draws[19] = 7.0
+    exp_draws[26] = 7.0
+    @test draws == exp_draws
+end

--- a/benchmark/bench/EpiObsModels/modifiers/Aggregate.jl
+++ b/benchmark/bench/EpiObsModels/modifiers/Aggregate.jl
@@ -1,0 +1,6 @@
+let
+    I_t = fill(10, 100)
+    weekly_agg = Aggregate(PoissonError(), [0, 0, 0, 0, 7, 0, 0])
+    mdl = generate_observations(weekly_agg, I_t, I_t)
+    suite["Aggregate"] = make_epiaware_suite(mdl)
+end


### PR DESCRIPTION
This PR closes #251 by adding a new `Aggregate` struct which sums expected observations based on a supplied aggregation vector (which is first broadcast to the full length). This is similar to the handling of daily -> weekly reporting in `EpiNow2` but more flexible and might be of interest to @jessalynnsebastian (though I think it isn't what we would want when `EpiAware` supports broadcasting expected observations to a reporting triangle.