### PR TITLE
Add a PR comment that tells readers how to install the current dev version of EpiAware

### DIFF
--- a/.github/workflows/try-this-pr.yaml
+++ b/.github/workflows/try-this-pr.yaml
@@ -1,0 +1,30 @@
+name: "Try this PR!"
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  write-comment:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `
+              ## Try this Pull Request!
+              Open Julia and type:
+              \`\`\`julia
+              import Pkg
+              Pkg.activate(temp=true)
+              Pkg.add(url="https://github.com/CDCgov/Rt-without-renewal", rev="${context.payload.pull_request.head.ref}", subdir="EpiAware")
+              using EpiAware}
+              \`\`\`
+              `
+            })


### PR DESCRIPTION
As the title. I think this could help streamline review and make sure we more often test out changes locally. It might also help those new to Julia begin reviewing.