### PR TITLE
Issue 340: Add a prefix to benchmarks

### DIFF
--- a/benchmark/make_epiaware_suite.jl
+++ b/benchmark/make_epiaware_suite.jl
@@ -3,7 +3,28 @@
 """
 function make_epiaware_suite(model; check = true,
         adbackends = [:forwarddiff, :reversediff, :reversediff_compiled])
-    suite = TuringBenchmarking.make_turing_suite(
-        model; check = check, adbackends = adbackends)
+    suite = prefix_warnings(
+        () -> TuringBenchmarking.make_turing_suite(
+            model; check = check, adbackends = adbackends),
+        model
+    )
     return suite
+end
+
+function prefix_warnings(f, g)
+    original_stderr = stderr
+    (read_pipe, write_pipe) = redirect_stderr()
+    result = nothing
+    try
+        result = f()
+    finally
+        redirect_stderr(original_stderr)
+        close(write_pipe)
+        output = String(read(read_pipe))
+        if !isempty(output)
+            println(stderr, "\nWarnings from $(g):")
+            println(stderr, output)
+        end
+    end
+    return result
 end


### PR DESCRIPTION
This PR partially addresses #340 by adding a prefix to any warnings produced by `make_turing_suite` based on the input `model`. This should help us locate potential issues more easily. 

@damonbayer if you have time to review this that would be great. We are looking at the output of the `benchmark` CI to see if it has worked.

You can run the `prefix_warnings` wrapper using this example/ 

```julia
# Define a struct instead of a function for g
struct G
    name::String
    threshold::Float64
end

# Define a function that uses the struct G
function process(g::G, x)
    if x < g.threshold
        @warn "Input is below threshold"
    end
    return x^2
end

# Define a function f that uses process with G
function f()
    g = G("MyProcessor", 0.0)
    result = process(g, -5)
    println("Result from process: $result")
    return result
end

# The prefix_warnings function remains the same
function prefix_warnings(f, g)
    original_stderr = stderr
    (read_pipe, write_pipe) = redirect_stderr()
    result = nothing
    try
        result = f()
    finally
        redirect_stderr(original_stderr)
        close(write_pipe)
        output = String(read(read_pipe))
        if !isempty(output)
            println(stderr, "\nWarnings from $(g):")
            println(stderr, output)
        end
    end
    return result
end

# Run the example
g = G("MyProcessor", 0.0)
result = prefix_warnings(f, g)
println("Final result: $result")
```

In principle yes the code in benchmarks should also have tests but I think we can leave for now as I am hoping that the Turing devs put something better than this in upstream.
