### PR TITLE
Change ARStep to reverse AR parameters

### DIFF
--- a/EpiAware/docs/src/showcase/replications/mishra-2020/index.jl
+++ b/EpiAware/docs/src/showcase/replications/mishra-2020/index.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.43
+# v0.19.46
 
 using Markdown
 using InteractiveUtils
@@ -545,7 +545,7 @@ let
         c = :black,
         lab = "prior")
 
-    p3 = histogram(inference_results.samples["latent.damp_AR[1]"],
+    p3 = histogram(inference_results.samples["latent.rev_damp_AR[2]"],
         lab = "chain " .* string.([1 2 3 4]),
         fillalpha = 0.4,
         lw = 0,
@@ -556,7 +556,7 @@ let
         c = :black,
         lab = "prior")
 
-    p4 = histogram(inference_results.samples["latent.damp_AR[2]"],
+    p4 = histogram(inference_results.samples["latent.rev_damp_AR[1]"],
         lab = "chain " .* string.([1 2 3 4]),
         fillalpha = 0.4,
         lw = 0,

--- a/EpiAware/src/EpiLatentModels/models/AR.jl
+++ b/EpiAware/src/EpiLatentModels/models/AR.jl
@@ -81,23 +81,26 @@ Generate a latent AR series.
     damp_AR ~ latent_model.damp_prior
     ϵ_t ~ filldist(Normal(), n - p)
 
-    ar = accumulate_scan(ARStep(damp_AR), ar_init, σ_AR * ϵ_t)
+    ar_step = ARStep(reverse(damp_AR))
+    ar = accumulate_scan(ar_step, ar_init, σ_AR * ϵ_t)
 
     return ar
 end
 
 @doc raw"
-The autoregressive (AR) step function struct
+The autoregressive (AR) step function struct.
+
+Note that the AR parameters are stored in reverse order.
 "
 struct ARStep{D <: AbstractVector{<:Real}} <: AbstractAccumulationStep
-    damp_AR::D
+    rev_damp_AR::D
 end
 
 @doc raw"
 The autoregressive (AR) step function for use with `accumulate_scan`.
 "
 function (ar::ARStep)(state, ϵ)
-    new_val = dot(ar.damp_AR, state) + ϵ
+    new_val = dot(ar.rev_damp_AR, state) + ϵ
     new_state = vcat(state[2:end], new_val)
     return new_state
 end

--- a/EpiAware/test/EpiLatentModels/models/AR.jl
+++ b/EpiAware/test/EpiLatentModels/models/AR.jl
@@ -92,7 +92,8 @@ end
 @testitem "Testing AR(2) process against theoretical properties" begin
     using DynamicPPL, Turing
     using HypothesisTests: ExactOneSampleKSTest, pvalue
-    using Distributions
+    using Distributions, Random
+    Random.seed!(1234)
 
     ar_model = AR(Normal(), HalfNormal(0.1), Normal(), p = 2)
     n = 10_000
@@ -109,7 +110,7 @@ end
     ar_init = rand(MvNormal(zeros(2), init_Σ))
 
     model = generate_latent(ar_model, n)
-    fixed_model = fix(model, (σ_AR = σ_AR, damp_AR = damp, ar_init = ar_init))
+    fixed_model = fix(model, (σ_AR = σ_AR, rev_damp_AR = reverse(damp), ar_init = ar_init))
     # Draw samples from the model
     X = fixed_model()
 

--- a/EpiAware/test/EpiLatentModels/models/AR.jl
+++ b/EpiAware/test/EpiLatentModels/models/AR.jl
@@ -96,7 +96,7 @@ end
     Random.seed!(1234)
 
     ar_model = AR(Normal(), HalfNormal(0.1), Normal(), p = 2)
-    n = 10_000
+    n = 1000
     damp = [0.8, 0.1]
     σ_AR = 1.0
 

--- a/EpiAware/test/EpiLatentModels/models/AR.jl
+++ b/EpiAware/test/EpiLatentModels/models/AR.jl
@@ -58,7 +58,7 @@ end
     end
 end
 
-@testitem "Testing AR process against theoretical properties" begin
+@testitem "Testing AR(1) process against theoretical properties" begin
     using DynamicPPL, Turing
     using HypothesisTests: ExactOneSampleKSTest, pvalue
     using Distributions
@@ -86,5 +86,34 @@ end
 
     ks_test_pval = ExactOneSampleKSTest(
         samples, Normal(theoretical_mean, sqrt(theoretical_var))) |> pvalue
+    @test ks_test_pval > 1e-6
+end
+
+@testitem "Testing AR(2) process against theoretical properties" begin
+    using DynamicPPL, Turing
+    using HypothesisTests: ExactOneSampleKSTest, pvalue
+    using Distributions
+
+    ar_model = AR(Normal(), HalfNormal(0.1), Normal(), p = 2)
+    n = 10_000
+    damp = [0.8, 0.1]
+    σ_AR = 1.0
+
+    theoretical_mean = 0.0
+    theoretical_var = σ_AR^2 / (1 - damp[1]^2 - damp[2]^2 -
+                       2 * (damp[1]^2 * damp[2] / (1 - damp[2])))
+    theoretical_1step_cov = theoretical_var * damp[1] / (1 - damp[2])
+    init_Σ = [theoretical_var theoretical_1step_cov; theoretical_1step_cov theoretical_var]
+
+    # Draw initial values from the stationary distribution so process starts at stationarity
+    ar_init = rand(MvNormal(zeros(2), init_Σ))
+
+    model = generate_latent(ar_model, n)
+    fixed_model = fix(model, (σ_AR = σ_AR, damp_AR = damp, ar_init = ar_init))
+    # Draw samples from the model
+    X = fixed_model()
+
+    ks_test_pval = ExactOneSampleKSTest(
+        X, Normal(theoretical_mean, sqrt(theoretical_var))) |> pvalue
     @test ks_test_pval > 1e-6
 end


### PR DESCRIPTION
This fixes #440 by choosing to reverse the AR parameters, whilst maintaining everything else as is.

To cover this bug I've also added a unit test that would have picked up swapping the AR parameters in an AR(2) process by comparing a long single draw to its known theoretical stationary distribution.

Closes #440 