### PR TITLE
change exp to xexpy

### DIFF
--- a/EpiAware/src/EpiInfModels/EpiInfModels.jl
+++ b/EpiAware/src/EpiInfModels/EpiInfModels.jl
@@ -6,7 +6,7 @@ module EpiInfModels
 using ..EpiAwareBase
 using ..EpiAwareUtils
 
-using Turing, Distributions, DocStringExtensions, LinearAlgebra
+using Turing, Distributions, DocStringExtensions, LinearAlgebra, LogExpFunctions
 
 #Export models
 export EpiData, DirectInfections, ExpGrowthRate, Renewal

--- a/EpiAware/src/EpiInfModels/ExpGrowthRate.jl
+++ b/EpiAware/src/EpiInfModels/ExpGrowthRate.jl
@@ -116,5 +116,5 @@ I_t = generated_quantities(latent_inf, θ)
 "
 @model function EpiAwareBase.generate_latent_infs(epi_model::ExpGrowthRate, rt)
     init_incidence ~ epi_model.initialisation_prior
-    return xexpy.(1.0, accumulate(+, rt; init = init_incidence))
+    return xexpy.(1.0, init_incidence .+ cumsum(rt))
 end

--- a/EpiAware/src/EpiInfModels/ExpGrowthRate.jl
+++ b/EpiAware/src/EpiInfModels/ExpGrowthRate.jl
@@ -116,5 +116,5 @@ I_t = generated_quantities(latent_inf, θ)
 "
 @model function EpiAwareBase.generate_latent_infs(epi_model::ExpGrowthRate, rt)
     init_incidence ~ epi_model.initialisation_prior
-    return exp.(init_incidence .+ cumsum(rt))
+    return xexpy.(1.0, accumulate(+, rt; init = init_incidence))
 end


### PR DESCRIPTION
This is a small PR to replace the calculation of `ExpGrowthRate` infection generating process with `LogExpFunctions.xexpy` to get their overflow properties. 

The reason I targeted this specific bit of the code base it that everywhere else we can define `transformation` whereas here the `exp` transform is baked into the meaning of the igp.

Closes #469 .

NB: I also changed from `cumsum` to `accumulate(+, rt; init = init_incidence)` to avoid a broadcast add before applying the "safe" `xexpy`. I wonder if anything shows in benchmarks.