### PR TITLE
Changed saved prior predictive data

### DIFF
--- a/pipeline/src/infer/InferenceConfig.jl
+++ b/pipeline/src/infer/InferenceConfig.jl
@@ -164,7 +164,7 @@ function infer(config::InferenceConfig)
         else
             fig = prior_predictive_plot(
                 config, inference_results, epiprob; ps = [0.025, 0.1, 0.25])
-            figdir = pipeline.testmode ? mktempdir() : plotsdir("priorpredictive")
+            figdir = config.pipeline.testmode ? mktempdir() : plotsdir("priorpredictive")
             figpath = joinpath(figdir, "priorpred_" * savename(save_config) * ".png")
             CairoMakie.save(figpath, fig)
             return Dict("priorpredictive" => "Pass", "inference_config" => save_config)

--- a/pipeline/src/infer/InferenceConfig.jl
+++ b/pipeline/src/infer/InferenceConfig.jl
@@ -12,13 +12,18 @@ Inference configuration struct for specifying the parameters and models used in 
 - `epimethod::E`: Inference method.
 - `transformation::F`: Transformation function.
 - `log_I0_prior::Distribution`: Prior for log initial infections. Default is `Normal(log(100.0), 1e-5)`.
+- `lookahead::X`: Number of days to forecast ahead.
+- `latent_model_name::String`: Name of the latent model.
+- `pipeline`: Pipeline type defining the inference scenario.
 
 # Constructors
 - `InferenceConfig(igp, latent_model, observation_model; gi_mean, gi_std, case_data, tspan, epimethod, transformation = exp)`: Constructs an `InferenceConfig` object with the specified parameters.
 - `InferenceConfig(inference_config::Dict; case_data, tspan, epimethod)`: Constructs an `InferenceConfig` object from a dictionary of configuration values.
 
 """
-struct InferenceConfig{T, F, IGP, L, O, E, D <: Distribution, X <: Integer}
+struct InferenceConfig{
+    T, F, IGP, L, O, E, D <: Distribution, X <: Integer,
+    P <: AbstractRtwithoutRenewalPipeline}
     gi_mean::T
     gi_std::T
     igp::IGP
@@ -33,21 +38,22 @@ struct InferenceConfig{T, F, IGP, L, O, E, D <: Distribution, X <: Integer}
     log_I0_prior::D
     lookahead::X
     latent_model_name::String
-    priorpredictive::Bool
+    pipeline::P
 
-    function InferenceConfig(igp, latent_model, observation_model; gi_mean, gi_std,
-            case_data, truth_I_t, truth_I0, tspan, epimethod,
-            transformation = exp, log_I0_prior, lookahead, latent_model_name, priorpredictive)
+    function InferenceConfig(
+            igp, latent_model, observation_model; gi_mean, gi_std, case_data,
+            truth_I_t, truth_I0, tspan, epimethod, transformation = exp,
+            log_I0_prior, lookahead, latent_model_name, pipeline)
         new{typeof(gi_mean), typeof(transformation), typeof(igp),
-            typeof(latent_model), typeof(observation_model),
-            typeof(epimethod), typeof(log_I0_prior), typeof(lookahead)}(
+            typeof(latent_model), typeof(observation_model), typeof(epimethod),
+            typeof(log_I0_prior), typeof(lookahead), typeof(pipeline)}(
             gi_mean, gi_std, igp, latent_model, observation_model,
             case_data, truth_I_t, truth_I0, tspan, epimethod,
-            transformation, log_I0_prior, lookahead, latent_model_name, priorpredictive)
+            transformation, log_I0_prior, lookahead, latent_model_name, pipeline)
     end
 
     function InferenceConfig(
-            inference_config::Dict; case_data, truth_I_t, truth_I0, tspan, epimethod, priorpredictive)
+            inference_config::Dict; case_data, truth_I_t, truth_I0, tspan, epimethod, pipeline)
         InferenceConfig(
             inference_config["igp"],
             inference_config["latent_namemodels"].second,
@@ -62,9 +68,38 @@ struct InferenceConfig{T, F, IGP, L, O, E, D <: Distribution, X <: Integer}
             log_I0_prior = inference_config["log_I0_prior"],
             lookahead = inference_config["lookahead"],
             latent_model_name = inference_config["latent_namemodels"].first,
-            priorpredictive
+            pipeline
         )
     end
+end
+
+"""
+Internal function that returns a dictionary containing key configuration fields from the given `InferenceConfig` object.
+The dictionary includes the following keys:
+
+- `"igp"`: The string representation of the `igp` field.
+- `"latent_model"`: The name of the latent model.
+- `"gi_mean"`: The mean of the generation interval.
+- `"gi_std"`: The standard deviation of the generation interval.
+- `"tspan"`: The time span for the inference.
+- `"priorpredictive"`: The prior predictive setting.
+
+# Arguments
+- `config::InferenceConfig`: An instance of `InferenceConfig` containing the configuration details.
+
+# Returns
+- `Dict{String, Any}`: A dictionary with the key configuration fields.
+"""
+function _saved_config_fields(config::InferenceConfig)
+    return Dict(
+        "igp" => string(config.igp),
+        "latent_model" => config.latent_model_name,
+        "gi_mean" => config.gi_mean,
+        "gi_std" => config.gi_std,
+        "tspan" => string(config.tspan[1]) * "_" * string(config.tspan[2]),
+        "priorpredictive" => config.pipeline.priorpredictive,
+        "scenario" => config.pipeline |> typeof |> string
+    )
 end
 
 """
@@ -112,6 +147,9 @@ function infer(config::InferenceConfig)
     #Define the EpiProblem
     epiprob = define_epiprob(config)
 
+    #Define savable configuration
+    save_config = _saved_config_fields(config)
+
     #Return the sampled infections and observations
     inference_results = try
         create_inference_results(config, epiprob)
@@ -119,15 +157,17 @@ function infer(config::InferenceConfig)
         e
     end
 
-    if config.priorpredictive
+    if config.pipeline.priorpredictive
         if inference_results isa Exception
-            return Dict("priorpredictive" => inference_results,
-                "epiprob" => epiprob, "inference_config" => config)
+            return Dict("priorpredictive" => string(inference_results),
+                "inference_config" => save_config)
         else
             fig = prior_predictive_plot(
                 config, inference_results, epiprob; ps = [0.025, 0.1, 0.25])
-            return Dict("priorpredictive" => fig, "epiprob" => epiprob,
-                "inference_config" => config)
+            figdir = pipeline.testmode ? mktempdir() : plotsdir("priorpredictive")
+            figpath = joinpath(figdir, "priorpred_" * savename(save_config) * ".png")
+            CairoMakie.save(figpath, fig)
+            return Dict("priorpredictive" => "Pass", "inference_config" => save_config)
         end
     else
         forecast_results = try
@@ -144,8 +184,8 @@ function infer(config::InferenceConfig)
             e
         end
 
-        return Dict("inference_results" => inference_results,
-            "epiprob" => epiprob, "inference_config" => config,
+        return Dict(
+            "inference_results" => inference_results, "inference_config" => save_config,
             "forecast_results" => forecast_results, "score_results" => score_results)
     end
 end

--- a/pipeline/src/infer/generate_inference_results.jl
+++ b/pipeline/src/infer/generate_inference_results.jl
@@ -20,7 +20,7 @@ function generate_inference_results(
     inference_method = make_inference_method(pipeline)
     config = InferenceConfig(
         inference_config; case_data = truthdata["y_t"], truth_I_t = truthdata["I_t"],
-        truth_I0 = truthdata["truth_I0"], tspan, epimethod = inference_method, priorpredictive = pipeline.priorpredictive)
+        truth_I0 = truthdata["truth_I0"], tspan, epimethod = inference_method, pipeline = pipeline)
 
     # produce or load inference results
     prfx = _inference_prefix(truthdata, inference_config, pipeline)
@@ -56,7 +56,7 @@ function generate_inference_results(
     inference_method = make_inference_method(pipeline)
     config = InferenceConfig(
         inference_config; case_data = truthdata["y_t"], truth_I_t = truthdata["I_t"],
-        truth_I0 = truthdata["truth_I0"], tspan = tspan, epimethod = inference_method)
+        truth_I0 = truthdata["truth_I0"], tspan = tspan, epimethod = inference_method, pipeline = pipeline)
 
     # produce or load inference results
     prfx = _inference_prefix(truthdata, inference_config, pipeline)

--- a/pipeline/src/infer/inference_helpers.jl
+++ b/pipeline/src/infer/inference_helpers.jl
@@ -64,5 +64,5 @@ Internal method for setting the data directory path for the inference data.
 _get_inferencedatadir_str(pipeline::AbstractEpiAwarePipeline) = datadir("epiaware_observables")
 function _get_inferencedatadir_str(pipeline::AbstractRtwithoutRenewalPipeline)
     pipeline.testmode ? mktempdir() :
-    pipeline.priorpredictive ? plotsdir("priorpredictive") : datadir("epiaware_observables")
+    pipeline.priorpredictive ? datadir("priorpredictive") : datadir("epiaware_observables")
 end

--- a/pipeline/test/forecast/test_forecast.jl
+++ b/pipeline/test/forecast/test_forecast.jl
@@ -10,7 +10,7 @@
     epimethod = make_inference_method(pipeline)
 
     epiprob = InferenceConfig(rand(inference_configs); case_data, truth_I_t = I_t,
-        truth_I0 = I0, tspan, epimethod, priorpredictive = pipeline.priorpredictive) |>
+        truth_I0 = I0, tspan, epimethod, pipeline = pipeline) |>
               define_epiprob
 
     @test_throws AssertionError define_forecast_epiprob(epiprob, -1)

--- a/pipeline/test/infer/test_InferenceConfig.jl
+++ b/pipeline/test/infer/test_InferenceConfig.jl
@@ -34,7 +34,7 @@
             log_I0_prior = Normal(log(100.0), 1e-5),
             lookahead = lookahead,
             latent_model_name = latent_model_name,
-            priorpredictive = false
+            pipeline = SmoothOutbreakPipeline()
         )
 
         @test config.gi_mean == gi_mean
@@ -52,7 +52,7 @@
         pipeline = SmoothOutbreakPipeline()
         inference_configs = make_inference_configs(pipeline)
         @test [InferenceConfig(ic; case_data, truth_I_t = I_t,
-                   truth_I0 = I0, tspan, epimethod, priorpredictive = pipeline.priorpredictive) isa
+                   truth_I0 = I0, tspan, epimethod, pipeline = pipeline) isa
                InferenceConfig
                for ic in inference_configs] |> all
     end

--- a/pipeline/test/infer/test_define_epiprob.jl
+++ b/pipeline/test/infer/test_define_epiprob.jl
@@ -10,7 +10,7 @@
     epimethod = make_inference_method(pipeline)
 
     epiprob = InferenceConfig(rand(inference_configs); case_data, tspan,
-        epimethod, truth_I_t = I_t, truth_I0 = I0, priorpredictive = pipeline.priorpredictive) |>
+        epimethod, truth_I_t = I_t, truth_I0 = I0, pipeline = pipeline) |>
               define_epiprob
 
     @test epiprob isa EpiProblem

--- a/pipeline/test/plotting/prior_pred_plot.jl
+++ b/pipeline/test/plotting/prior_pred_plot.jl
@@ -13,5 +13,5 @@
 
     fig = results["priorpredictive"]
 
-    @test fig isa Figure
+    @test fig isa String #Figure object no longer returned
 end


### PR DESCRIPTION
This PR changes the serialisation behaviour of the pipeline to reduce unnecessary objects being serialised (less important) and deals with problems in deserialising around reconstructing arbitrary Julia types (more important).

Closes #477 .

NB: While doing this PR, I was passing more pipeline data to `infer`... so it became easier to just pass the `pipeline` struct instance. This lets us select the inference post-processing based on the pipeline (e.g. testmode, priorpredictive etc). There might be a slicker way to do this which we can revisit in the future.