### PR TITLE
Update .gitignore for new Manifest files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,7 +379,6 @@ docs/site/
 # such, it should not be committed for packages, but should be committed for
 # applications that require a static environment.
 #Manifest.toml
-/Manifest.toml
 .DS_Store
 .vscode/settings.json
 
@@ -390,3 +389,4 @@ EpiAware/docs/src/examples/*.md
 /.benchmarkci
 /benchmark/*.json
 EpiAware/docs/src/getting-started/tutorials/censored-obs.md
+*/Manifest*.toml


### PR DESCRIPTION
This PR closes #484 

I've moved to `julia-1.11` locally, but retaining a `Manifest-v1.10.toml` is handy (both for `EpiAware` and `EpiAwarePipeline`). This small PR means these are not committed to origin.