### PR TITLE
Change transformation for Renewal model in test suite

### DIFF
--- a/EpiAware/test/EpiObsModels/modifiers/LatentDelay.jl
+++ b/EpiAware/test/EpiObsModels/modifiers/LatentDelay.jl
@@ -164,7 +164,8 @@ end
 
 @testitem "LatentDelay parameter recovery with mix of IGP + latent processes: Negative binomial errors + EpiProblem interface" begin
     using Random, Turing, Distributions, LinearAlgebra, DynamicPPL, StatsBase, ReverseDiff,
-          Suppressor
+          Suppressor, LogExpFunctions
+    # using PairPlots, CairoMakie
     Random.seed!(1234)
 
     #Set up model testing matrix
@@ -173,8 +174,12 @@ end
         DirectInfections,
         ExpGrowthRate,
         Renewal] .|>
-                em_type -> em_type(data = EpiData([0.2, 0.5, 0.3], exp),
-        initialisation_prior = Normal(log(100.0), 0.25))
+                em_type -> em_type(
+        data = EpiData([0.2, 0.5, 0.3],
+            em_type == Renewal ? softplus : exp
+        ),
+        initialisation_prior = Normal(log(100.0), 0.25)
+    )
 
     latentprocess_types = [RandomWalk, AR, DiffLatentModel]
 


### PR DESCRIPTION
This PR closes #490 

This PR makes the CI parameter recovery more robust by changing the `transformation` defined by `EpiData` from `exp` to `softplus`.

NB: Since the `exp` transform is very commonly used for $R_t$ for example in [EpiNow2](https://epiforecasts.io/EpiNow2/articles/estimate_infections.html#time-varying-reproduction-number) we might want to consider the problem in more detail despite this fix.

## Mathematical details

Softplus transformation and its inverse:

```math
\begin{aligned}
\text{softplus}(x) &= \log(1 + \exp(x)) \\
\text{invsoftplus}(y) &= \log(\exp(y) - 1)
\end{aligned}
```

In the parameter recovery test I have modified to do:

```math
\text{invsoftplus}(R_t) \sim Z_t
```
Where $Z_t$ is the latent process being tested (e.g. random walk, AR(1) and Diff AR(1)).

