### PR TITLE
Issue 471: Changing ascertainment to transform x and y vs just y

### DIFF
--- a/EpiAware/src/EpiObsModels/EpiObsModels.jl
+++ b/EpiAware/src/EpiObsModels/EpiObsModels.jl
@@ -11,6 +11,7 @@ using ..EpiLatentModels: HierarchicalNormal, broadcast_dayofweek
 using ..EpiLatentModels: broadcast_rule, PrefixLatentModel, RepeatEach
 
 using Turing, Distributions, DocStringExtensions, SparseArrays, LinearAlgebra
+using LogExpFunctions: xexpy
 
 # Observation error models
 export PoissonError, NegativeBinomialError

--- a/EpiAware/src/EpiObsModels/modifiers/ascertainment/helpers.jl
+++ b/EpiAware/src/EpiObsModels/modifiers/ascertainment/helpers.jl
@@ -5,7 +5,7 @@ Create an `Ascertainment` object that models the ascertainment process based on 
 # Arguments
 - `model::AbstractTuringObservationModel`: The observation model to be used.
 - `latent_model::AbstractTuringLatentModel`: The latent model to be used. Default is `HierarchicalNormal()` which is a hierarchical normal distribution.
-- `link`: The link function to be used. Default is the identity map `x -> x`.
+- `transform`: The transform function to be used. Default is `(x, y) -> x .* y`.
 This function is used to transform the latent model _after_ broadcasting to
 periodic weekly has been applied.
 - `latent_prefix`: The prefix to be used for the latent model. Default is `\"DayofWeek\"`.
@@ -25,6 +25,6 @@ rand(gen_obs)
 "
 function ascertainment_dayofweek(model::AbstractTuringObservationModel;
         latent_model::AbstractTuringLatentModel = HierarchicalNormal(),
-        link = x -> x, latent_prefix = "DayofWeek")
-    return Ascertainment(model, broadcast_dayofweek(latent_model), link, latent_prefix)
+        transform = (x, y) -> x .* y, latent_prefix = "DayofWeek")
+    return Ascertainment(model, broadcast_dayofweek(latent_model), transform, latent_prefix)
 end

--- a/EpiAware/test/EpiAwareUtils/turing-methods.jl
+++ b/EpiAware/test/EpiAwareUtils/turing-methods.jl
@@ -75,8 +75,7 @@ end
 
     # Used again in obs model
 
-    obs_ascert = Ascertainment(PoissonError(), ar_process; link = x -> exp.(x))
-
+    obs_ascert = Ascertainment(PoissonError(), ar_process)
     #Epi model
     gen_int = [0.2, 0.3, 0.5]
     transformation = x -> exp.(x)

--- a/EpiAware/test/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
+++ b/EpiAware/test/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
@@ -1,32 +1,53 @@
 @testitem "Test Ascertainment constructor" begin
-    using Turing
-    function natural(x)
-        return x
-    end
+    using Turing, LogExpFunctions
 
-    asc = Ascertainment(NegativeBinomialError(), FixedIntercept(0.1); link = natural)
+    asc = Ascertainment(NegativeBinomialError(), FixedIntercept(0.1))
     @test asc.model == NegativeBinomialError()
     @test asc.latent_model == PrefixLatentModel(FixedIntercept(0.1), "Ascertainment")
-    @test asc.link == natural
+    # Test transform function
+    Y_t = [1.0, 2.0]
+    x = [0.1, 0.2]
+    expected_result = LogExpFunctions.xexpy.(Y_t, x)
+    @test all(isapprox.(asc.transform(Y_t, x), expected_result, atol = 1e-6))
     @test asc.latent_prefix == "Ascertainment"
 
-    asc_prefix = Ascertainment(NegativeBinomialError(), FixedIntercept(0.1);
-        link = natural, latent_prefix = "A")
-    @test asc_prefix.model == NegativeBinomialError()
-    @test asc_prefix.latent_model == PrefixLatentModel(FixedIntercept(0.1), "A")
-    @test asc_prefix.link == natural
-    @test asc_prefix.latent_prefix == "A"
+    custom_transform(Y_t, x) = Y_t .* exp.(x)
+    asc_custom = Ascertainment(NegativeBinomialError(), FixedIntercept(0.1);
+        transform = custom_transform, latent_prefix = "A")
+    @test asc_custom.model == NegativeBinomialError()
+    @test asc_custom.latent_model == PrefixLatentModel(FixedIntercept(0.1), "A")
+    @test asc_custom.transform == custom_transform
+    @test asc_custom.latent_prefix == "A"
 end
 
-# make a test based on above example
 @testitem "Test Ascertainment generate_observations" begin
     using Turing
 
-    obs = Ascertainment(
-        RecordExpectedObs(NegativeBinomialError()), FixedIntercept(0.1); link = x -> x)
-    gen_obs = generate_observations(obs, missing, fill(100, 10))
+    obs = Ascertainment(RecordExpectedObs(NegativeBinomialError()), FixedIntercept(0.1))
+    gen_obs = generate_observations(obs, missing, fill(100.0, 10))
     samples = sample(gen_obs, Prior(), 100; progress = false)
     gen = get(samples, :exp_y_t).exp_y_t |>
           x -> vcat(x...)
-    @test all(gen .== 10.0)
+    @test all(isapprox.(gen, 110.517, atol = 1e-3))
+
+    # Test with custom transform
+    custom_transform(Y_t, x) = Y_t .* (1 .+ x)
+    obs_custom = Ascertainment(
+        RecordExpectedObs(NegativeBinomialError()),
+        FixedIntercept(0.1),
+        transform = custom_transform
+    )
+    gen_obs_custom = generate_observations(obs_custom, missing, fill(100.0, 10))
+    samples_custom = sample(gen_obs_custom, Prior(), 100; progress = false)
+    gen_custom = get(samples_custom, :exp_y_t).exp_y_t |>
+                 x -> vcat(x...)
+    @test all(isapprox.(gen_custom, 110.0, atol = 1e-3))
+end
+
+@testitem "Test Ascertainment constructor with invalid transform" begin
+    @test_throws ArgumentError Ascertainment(
+        NegativeBinomialError(),
+        FixedIntercept(0.1),
+        transform = x -> exp.(x)
+    )
 end

--- a/benchmark/bench/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
+++ b/benchmark/bench/EpiObsModels/modifiers/ascertainment/Ascertainment.jl
@@ -1,5 +1,5 @@
 let
-    obs = Ascertainment(NegativeBinomialError(), FixedIntercept(0.1); link = x -> x)
+    obs = Ascertainment(NegativeBinomialError(), FixedIntercept(0.1))
     I_t = fill(100, 10)
     gen_obs = generate_observations(obs, I_t, I_t)
     suite["Ascertainment"] = make_epiaware_suite(gen_obs)


### PR DESCRIPTION
As the title this PR partially addresses #471 by changing the structure of `Ascertainment` to take a transform function rather than a link. It also updates the default here to use `LogExpFunctions`. This is then propagated through the ascertainment day of week helper. I've slightly expanded the test suite and added a check in the `Ascertainment` struct that just checks for the input having two arguments - these could be expanded at a later date.