### PR TITLE
Issue 507: Add EpiAware dev source path + nb changes

### DIFF
--- a/EpiAware/docs/Project.toml
+++ b/EpiAware/docs/Project.toml
@@ -20,5 +20,7 @@ SciMLSensitivity = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
-Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
+
+[sources]
+EpiAware = {path = "./../"}

--- a/EpiAware/docs/src/getting-started/tutorials/censored-obs.jl
+++ b/EpiAware/docs/src/getting-started/tutorials/censored-obs.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.46
+# v0.20.0
 
 using Markdown
 using InteractiveUtils
@@ -7,11 +7,8 @@ using InteractiveUtils
 # ╔═╡ a2624404-48b1-4faa-abbe-6d78b8e04f2b
 let
     docs_dir = dirname(dirname(dirname(@__DIR__)))
-    pkg_dir = dirname(docs_dir)
-
     using Pkg: Pkg
     Pkg.activate(docs_dir)
-    Pkg.develop(; path = pkg_dir)
     Pkg.instantiate()
 end
 

--- a/EpiAware/docs/src/showcase/replications/chatzilena-2019/index.jl
+++ b/EpiAware/docs/src/showcase/replications/chatzilena-2019/index.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.46
+# v0.20.0
 
 using Markdown
 using InteractiveUtils
@@ -7,11 +7,8 @@ using InteractiveUtils
 # ╔═╡ e34cec5a-a173-4e92-a860-340c7a9e9c72
 let
     docs_dir = dirname(dirname(dirname(dirname(@__DIR__))))
-    pkg_dir = dirname(docs_dir)
-
     using Pkg: Pkg
     Pkg.activate(docs_dir)
-    Pkg.develop(; path = pkg_dir)
     Pkg.instantiate()
 end;
 

--- a/EpiAware/docs/src/showcase/replications/mishra-2020/index.jl
+++ b/EpiAware/docs/src/showcase/replications/mishra-2020/index.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.46
+# v0.20.0
 
 using Markdown
 using InteractiveUtils
@@ -7,11 +7,8 @@ using InteractiveUtils
 # ╔═╡ 34a06b3b-799b-48c5-bd08-1e57151f51ec
 let
     docs_dir = dirname(dirname(dirname(dirname(@__DIR__))))
-    pkg_dir = dirname(docs_dir)
-
     using Pkg: Pkg
     Pkg.activate(docs_dir)
-    Pkg.develop(; path = pkg_dir)
     Pkg.instantiate()
 end;
 
@@ -394,7 +391,7 @@ num_threads = min(10, Threads.nthreads())
 inference_method = EpiMethod(
     pre_sampler_steps = [ManyPathfinder(nruns = 4, maxiters = 100)],
     sampler = NUTSampler(
-        adtype = AutoReverseDiff(),
+        adtype = AutoReverseDiff(compile = true),
         ndraws = 2000,
         nchains = num_threads,
         mcmc_parallel = MCMCThreads())


### PR DESCRIPTION
This small PR closes #507 .

It adds a `[sources]` section to the `docs` environment with a `path` to `EpiAware`. This allows us to eliminate usage of `Pkg.develop` within Pluto nbs.