### PR TITLE
CompatHelper overwrite vs append

### DIFF
--- a/.github/workflows/CompatHelper-EpiAware.yaml
+++ b/.github/workflows/CompatHelper-EpiAware.yaml
@@ -36,8 +36,6 @@ jobs:
         run: |
             using CompatHelper;
             CompatHelper.main(;
-              entry_type = DropEntry(),
-              subdirs = ["EpiAware"], 
-              bump_version = true
+              entry_type = DropEntry(), subdirs = ["EpiAware"], bump_version = true
             )
         shell: julia --color=yes {0}

--- a/.github/workflows/CompatHelper-EpiAware.yaml
+++ b/.github/workflows/CompatHelper-EpiAware.yaml
@@ -36,6 +36,8 @@ jobs:
         run: |
             using CompatHelper;
             CompatHelper.main(;
-              subdirs = ["EpiAware"], bump_version = true
+              entry_type = DropEntry(),
+              subdirs = ["EpiAware"], 
+              bump_version = true
             )
         shell: julia --color=yes {0}


### PR DESCRIPTION
CompatHelper updated to only keep the latest version vs appending. This way we are testing all combinations of dependencies and we know it works. The downside is potential for it to be annoying for users but I think this is fairly low priority.