### PR TITLE
Hotfix: remove prefix_submodel doctest

### DIFF
--- a/EpiAware/src/EpiAwareUtils/prefix_submodel.jl
+++ b/EpiAware/src/EpiAwareUtils/prefix_submodel.jl
@@ -13,13 +13,9 @@ Generate a submodel with an optional prefix. A lightweight wrapper around the `@
 
 # Examples
 
-```jldoctest
+```julia
 using EpiAware, DynamicPPL
-
 submodel = prefix_submodel(FixedIntercept(0.1), generate_latent, string(1), 2)
-submodel
-# output
-Model{typeof(prefix_submodel), (:model, :fn, :prefix, Symbol(\"#splat#kwargs\")), (), (), Tuple{FixedIntercept{Float64}, typeof(generate_latent), String, Tuple{Int64}}, Tuple{}, DefaultContext}(EpiAware.EpiAwareUtils.prefix_submodel, (model = FixedIntercept{Float64}(0.1), fn = EpiAware.EpiAwareBase.generate_latent, prefix = \"1\", var\"#splat#kwargs\" = (2,)), NamedTuple(), DefaultContext())
 ```
 
 We can now draw a sample from the submodel.

--- a/EpiAware/src/EpiAwareUtils/prefix_submodel.jl
+++ b/EpiAware/src/EpiAwareUtils/prefix_submodel.jl
@@ -13,7 +13,7 @@ Generate a submodel with an optional prefix. A lightweight wrapper around the `@
 
 # Examples
 
-```julia
+```@example
 using EpiAware, DynamicPPL
 submodel = prefix_submodel(FixedIntercept(0.1), generate_latent, string(1), 2)
 ```


### PR DESCRIPTION
It turns out the precise struct description (i.e. non-pretty print `show` of the struct) has changed.

Since this is quite complicated and brittle, the hotfix is to just swap this to being a standard `julia` block in the docstring. Note that this docstring only really covered that call the prefix function didn't error which is also covered in our unit tests.