### PR TITLE
Patch: Switch to fork of benchmarkCI

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -22,8 +22,6 @@ jobs:
         run: |
           julia --project=benchmark -e 'using Pkg;
           Pkg.rm("EpiAware");
-          Pkg.rm("BenchmarkCI");
-          Pkg.add(url="https://github.com/SamuelBrand1/BenchmarkCI.jl");
           Pkg.resolve();
           Pkg.instantiate();
           Pkg.develop(path = "./EpiAware")'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Install dependencies
         run: |
           julia --project=benchmark -e 'using Pkg;
-          Pkg.rm("EpiAware");
           Pkg.resolve();
+          Pkg.rm("EpiAware");
           Pkg.instantiate();
           Pkg.develop(path = "./EpiAware")'
       - name: Run benchmarks

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -22,9 +22,7 @@ jobs:
         run: |
           julia --project=benchmark -e 'using Pkg;
           Pkg.resolve();
-          Pkg.rm("EpiAware");
-          Pkg.instantiate();
-          Pkg.develop(path = "./EpiAware")'
+          Pkg.instantiate()'
       - name: Run benchmarks
         run: julia --project=benchmark -e 'using BenchmarkCI; BenchmarkCI.judge(; baseline = "origin/main", retune = true)'
       - name: Post results

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -22,6 +22,8 @@ jobs:
         run: |
           julia --project=benchmark -e 'using Pkg;
           Pkg.rm("EpiAware");
+          Pkg.rm("BenchmarkCI");
+          Pkg.add(url="https://github.com/SamuelBrand1/BenchmarkCI.jl");
           Pkg.resolve();
           Pkg.instantiate();
           Pkg.develop(path = "./EpiAware")'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -21,8 +21,11 @@ jobs:
       - name: Install dependencies
         run: |
           julia --project=benchmark -e 'using Pkg;
+          Pkg.rm("EpiAware");
+          Pkg.add(url="https://github.com/SamuelBrand1/BenchmarkCI.jl");
           Pkg.resolve();
-          Pkg.instantiate()'
+          Pkg.instantiate();
+          Pkg.develop(path = "./EpiAware")'
       - name: Run benchmarks
         run: julia --project=benchmark -e 'using BenchmarkCI; BenchmarkCI.judge(; baseline = "origin/main", retune = true)'
       - name: Post results

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-BenchmarkCI = "20533458-34a3-403d-a444-e18f38190b5b"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
@@ -7,7 +6,3 @@ EpiAware = "b2eeebe4-5992-4301-9193-7ebc9f62c855"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 TuringBenchmarking = "0db1332d-5c25-4deb-809f-459bc696f94f"
-
-[sources]
-BenchmarkCI = {url = "https://github.com/SamuelBrand1/BenchmarkCI.jl"}
-EpiAware = {path = "../EpiAware"}

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -10,4 +10,4 @@ TuringBenchmarking = "0db1332d-5c25-4deb-809f-459bc696f94f"
 
 [sources]
 BenchmarkCI = {url = "https://github.com/SamuelBrand1/BenchmarkCI.jl"}
-EpiAware = {path = "./EpiAware"}
+EpiAware = {path = "../EpiAware"}

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -10,3 +10,4 @@ TuringBenchmarking = "0db1332d-5c25-4deb-809f-459bc696f94f"
 
 [sources]
 BenchmarkCI = {url = "https://github.com/SamuelBrand1/BenchmarkCI.jl"}
+EpiAware = {path = "./EpiAware"}

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -7,3 +7,6 @@ EpiAware = "b2eeebe4-5992-4301-9193-7ebc9f62c855"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 TuringBenchmarking = "0db1332d-5c25-4deb-809f-459bc696f94f"
+
+[sources]
+BenchmarkCI = {url = "https://github.com/SamuelBrand1/BenchmarkCI.jl"}


### PR DESCRIPTION
The goal of this is to switch `main` to using the fork of benchmarkCI and contribute to closing #511 .