### PR TITLE
trigger with manifest-- do not merge

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -21,10 +21,9 @@ jobs:
       - name: Install dependencies
         run: |
           julia --project=benchmark -e 'using Pkg;
-          Pkg.instantiate();
-          Pkg.update()'
+          Pkg.instantiate()'
       - name: Run benchmarks
-        run: julia --project=benchmark -e 'using BenchmarkCI; BenchmarkCI.judge(; baseline = "origin/main", retune = true)'
+        run: julia --project=benchmark -e 'using BenchmarkCI; BenchmarkCI.judge(; baseline = "origin/trigger-bci", retune = true)'
       - name: Post results
         run: julia --project=benchmark -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
         env:

--- a/EpiAware/test/EpiAwareBase/EpiMethod.jl
+++ b/EpiAware/test/EpiAwareBase/EpiMethod.jl
@@ -12,3 +12,7 @@
         @test method.sampler == sampler
     end
 end
+
+@testitem "trigger" begin
+    @test true
+end


### PR DESCRIPTION
This is a test draft PR to test if manifest specification of benchmarks avoids CI creating uncommitted tracked changes which downstream cause Pkgbenchmark to fail