### PR TITLE
Set version to 0.1.0

### DIFF
--- a/EpiAware/Project.toml
+++ b/EpiAware/Project.toml
@@ -1,7 +1,7 @@
 name = "EpiAware"
 uuid = "b2eeebe4-5992-4301-9193-7ebc9f62c855"
 authors = ["Samuel Abbott <azw1@cdc.gov>", "Samuel Brand <usi1@cdc.gov>", "Zachary Susswein <utb2@cdc.gov>"]
-version = "0.1.0-DEV"
+version = "0.1.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rtwithoutrenewal"
 uuid = "5f18122a-2e46-11ef-2c26-2d57cbc8fe48"
 authors = ["Samuel Abbott <azw1@cdc.gov>", "Samuel Brand <usi1@cdc.gov>", "Zachary Susswein <utb2@cdc.gov>"]
-version = "0.1.0-DEV"
+version = "0.1.0"
 
 [deps]
 EpiAware = "b2eeebe4-5992-4301-9193-7ebc9f62c855"


### PR DESCRIPTION
This mini-PR changes the versions recorded in the root `Project.toml` and the `EpiAware` `Project.toml` to `0.1.0` as discussed with @seabbs .

This is ahead of a tagged github release.