### PR TITLE
Issue 561: Soft min transformation

### DIFF
--- a/pipeline/src/constructors/make_observation_model.jl
+++ b/pipeline/src/constructors/make_observation_model.jl
@@ -1,5 +1,5 @@
 """
-Constructs an observation model for the given pipeline. This is the defualt method.
+Constructs an observation model for the given pipeline. This is the default method.
 
 # Arguments
 - `pipeline::AbstractEpiAwarePipeline`: The pipeline for which the observation model is constructed.
@@ -12,6 +12,26 @@ function make_observation_model(pipeline::AbstractEpiAwarePipeline)
     default_params = make_default_params(pipeline)
     #Model for ascertainment based on day of the week
     dayofweek_logit_ascert = ascertainment_dayofweek(NegativeBinomialError(cluster_factor_prior = HalfNormal(default_params["cluster_factor"])))
+    #Default continuous-time model for latent delay in observations
+    delay_distribution = make_delay_distribution(pipeline)
+    #Model for latent delay in observations
+    obs = LatentDelay(dayofweek_logit_ascert, delay_distribution)
+    return obs
+end
+
+const negC = -1e15
+"""
+Soft minimum function for a smooth transition from `x -> x` to a maximum value of 1e15.
+"""
+_softmin(x) = -logaddexp(negC, -x)
+
+function make_observation_model(pipeline::AbstractRtwithoutRenewalPipeline)
+    default_params = make_default_params(pipeline)
+    #Model for ascertainment based on day of the week
+    dayofweek_logit_ascert = ascertainment_dayofweek(
+        NegativeBinomialError(cluster_factor_prior = HalfNormal(default_params["cluster_factor"]));
+        transform = (x, y) -> _softmin.(x .* y))
+
     #Default continuous-time model for latent delay in observations
     delay_distribution = make_delay_distribution(pipeline)
     #Model for latent delay in observations

--- a/pipeline/test/pipeline/test_pipelinefunctions.jl
+++ b/pipeline/test/pipeline/test_pipelinefunctions.jl
@@ -13,16 +13,14 @@ end
 
 @testset "do_inference tests" begin
     function make_inference(pipeline)
-        truthdata_dg_task = do_truthdata(pipeline)
-        truthdata = fetch.(truthdata_dg_task)
+        truthdata = do_truthdata(pipeline)
         do_inference(truthdata[1], pipeline)
     end
 
     for pipetype in [SmoothOutbreakPipeline, MeasuresOutbreakPipeline,
         SmoothEndemicPipeline, RoughEndemicPipeline]
-        pipeline = pipetype(; ndraws = 20, nchains = 1, testmode = true)
-        inference_results_tsk = make_inference(pipeline)
-        inference_results = fetch.(inference_results_tsk)
+        pipeline = pipetype(; ndraws = 1000, nchains = 1, testmode = true)
+        inference_results = make_inference(pipeline)
         @test length(inference_results) == 1
         @test all([result["inference_results"] isa EpiAwareObservables
                    for result in inference_results])


### PR DESCRIPTION
This PR closes #561.

This is a small PR which simply redefines the `Ascertainment` part of the observation model composition to have a custom transformation which soft mins the _expected_ observations at `1e15` chosen so that the `InexactErrors` are not caused by wild sampling in some models.

I also increased the pipeline test draws to better check if this is operating as expected.

PS 

I've done this as an extension of the work in #560 so if @seabbs is happy with that we can do this PR as a 2-fer.

Minor change: I noted that `fetch` was still being used in the tests as a legacy of using `Dagger.jl`. This didn't error because it has a sensible `Base` default but I've removed as unnecessary.