### PR TITLE
Issue 563: Change lookback to 90 time steps

### DIFF
--- a/pipeline/src/constructors/make_default_params.jl
+++ b/pipeline/src/constructors/make_default_params.jl
@@ -22,7 +22,7 @@ function make_default_params(pipeline::AbstractEpiAwarePipeline)
     α_delay = 4.0
     θ_delay = 5.0 / 4.0
     lookahead = 21
-    lookback = 35
+    lookback = 90
     stride = 7
     return Dict(
         "Rt" => Rt,

--- a/pipeline/src/constructors/make_tspan.jl
+++ b/pipeline/src/constructors/make_tspan.jl
@@ -7,7 +7,7 @@ Constructs a time span for performing inference on a case data time series. This
 - `T::Union{Integer,Nothing} = nothing`: The `stop` point at which to construct
     the time span. If `nothing`, the time span will be constructed using the
     length of the Rt vector for `pipeline`.
-- `lookback = 35`: The number of days to look back from the specified time point.
+- `lookback`: The number of days to look back from the specified time point.
 
 # Returns
 A tuple `(start, stop)` representing the start and stop indices of the time span.
@@ -16,7 +16,7 @@ A tuple `(start, stop)` representing the start and stop indices of the time span
 
 """
 function make_tspan(pipeline::AbstractEpiAwarePipeline;
-        T::Union{Integer, Nothing} = nothing, lookback = 35)
+        T::Union{Integer, Nothing} = nothing, lookback)
     N = size(make_Rt(pipeline), 1)
     _T = isnothing(T) ? N : T
     return (max(1, _T - lookback), min(N, _T))

--- a/pipeline/src/infer/InferenceConfig.jl
+++ b/pipeline/src/infer/InferenceConfig.jl
@@ -118,8 +118,10 @@ to make inference on and model configuration.
 function create_inference_results(config, epiprob)
     #Return the sampled infections and observations
     idxs = config.tspan[1]:config.tspan[2]
+    #Subselect the case data to the time span
     y_t = ismissing(config.case_data) ? missing :
           Vector{Union{Missing, Int64}}(config.case_data[idxs])
+    #Run inference once
     inference_results = apply_method(epiprob,
         config.epimethod,
         (y_t = y_t,)

--- a/pipeline/test/constructors/test_constructors.jl
+++ b/pipeline/test/constructors/test_constructors.jl
@@ -24,7 +24,7 @@ end
 @testset "default_tspan: returns an Tuple{Integer, Integer}" begin
     pipeline = EpiAwareExamplePipeline()
 
-    tspan = make_tspan(pipeline)
+    tspan = make_tspan(pipeline; lookback = 90)
     @test tspan isa Tuple{Integer, Integer}
 end
 
@@ -138,7 +138,7 @@ end
         "α_delay" => 4.0,
         "θ_delay" => 5.0 / 4.0,
         "lookahead" => 21,
-        "lookback" => 35,
+        "lookback" => 90,
         "stride" => 7
     )
 


### PR DESCRIPTION
This small PR closes #563 .

All this PR does is change the lookback to 90 time steps. This removes the windowing effect on the Rt-without project whilst leaving a more reasonable default for any extension to a longer time series.