### PR TITLE
trigger CI to test CI duration -- Do not merge

### DIFF
--- a/EpiAware/test/EpiAwareBase/EpiMethod.jl
+++ b/EpiAware/test/EpiAwareBase/EpiMethod.jl
@@ -12,3 +12,7 @@
         @test method.sampler == sampler
     end
 end
+
+@testitem "Trigger" begin
+    @test true
+end


### PR DESCRIPTION
This is a test to trigger the CI and record the duration. The reason is that #569 CI is now taking a very long time, despite no evidence of slower model calls from our benchmarking.

NB: I'm not finding a slow down on running the test suite from local, and the inference examples in the documentation seem to run and render in normal time. Quite mysterious.