### PR TITLE
Issue 579: update test-epiaware with depwarn no

### DIFF
--- a/.github/workflows/codecoverage-EpiAware.yaml
+++ b/.github/workflows/codecoverage-EpiAware.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           annotate: true
+          depwarn: 'no'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/depwarn-check.yaml
+++ b/.github/workflows/depwarn-check.yaml
@@ -1,0 +1,31 @@
+name: Depreciation warnings
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: EpiAware
+          sparse-checkout-cone-mode: false
+      - name: Move EpiAware to root
+        run: mv EpiAware/* .
+      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: 'yes'

--- a/.github/workflows/test-EpiAware.yaml
+++ b/.github/workflows/test-EpiAware.yaml
@@ -32,3 +32,5 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          depwarn: 'no'


### PR DESCRIPTION
As per title this PR closes #579

The strategy here is to set `depwarn` to `no` for the test suite and add a new CI which will flag dep warns.